### PR TITLE
Added a main in the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
-{   "name" : "jslint"
-,   "version" : "0.0.3"
+{   "name" : "readyjslint"
+,   "version" : "0.0.4"
 ,   "engines" : { "node" : ">=0.1.97" }
 ,   "author" : "Douglas Crockford <douglas@crockford.com>"
 ,   "contributors" :
@@ -10,4 +10,5 @@
 ,       "Anders Conbere <aconbere@gmail.com>"
 ]
 ,   "bin" : { "jslint" : "./bin/jslint.js" }
+,   "main" : "./lib/fulljslint_export.js"
 }


### PR DESCRIPTION
Hi,
I added a main in the package.json of the project that let us use jslint programmatically. I needed it for ready.js (http://github.com/dsimard/ready.js) so I created my own package for now called readyjslint . Let me know when it's merged.

Thanks!
