### PR TITLE
Add main so jslint can be used as a library

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "bin": {
         "jslint": "./bin/jslint.js"
     },
+    "main": "./lib/jslint.js",
     "dependencies": {
         "nopt": "~1.0.0"
     },


### PR DESCRIPTION
This pull request adds a "main" configuration to package.json to allow jslint to be used as library instead of command line application.
