### PR TITLE
predef option now accepts multiple string values.

### DIFF
--- a/bin/jslint.js
+++ b/bin/jslint.js
@@ -18,7 +18,7 @@ function commandOptions () {
         'indent' : Number,
         'maxerr' : Number,
         'maxlen' : Number,
-        'predef' : [String, null]
+        'predef' : [String, Array]
     };
 
     flags.forEach(function (option) {


### PR DESCRIPTION
Previously predef could only accept at most one string as option,
meaning there could be at most one global variable. Now predef accepts
multiple strings by "--predef foo --predef bar".
