### PR TITLE
Updated jslint.js source to new version

### DIFF
--- a/lib/jslint.js
+++ b/lib/jslint.js
@@ -1,5 +1,5 @@
 // jslint.js
-// 2011-05-10
+// 2011-11-03
 
 // Copyright (c) 2002 Douglas Crockford  (www.JSLint.com)
 
@@ -23,6 +23,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+// WARNING: JSLint will hurt your feelings.
 
 // JSLINT is a global function. It takes two parameters.
 
@@ -91,9 +92,9 @@
 //                 name: STRING,
 //                 line: NUMBER,
 //                 last: NUMBER,
-//                 param: [
+//                 params: [
 //                     {
-//                         value: STRING
+//                         string: STRING
 //                     }
 //                 ],
 //                 closure: [
@@ -111,6 +112,9 @@
 //                 unused: [
 //                     STRING
 //                 ],
+//                 undef: [
+//                     STRING
+//                 ],
 //                 global: [
 //                     STRING
 //                 ],
@@ -125,18 +129,6 @@
 //         member: {
 //             STRING: NUMBER
 //         },
-//         unuseds: [
-//             {
-//                 name: STRING,
-//                 line: NUMBER
-//             }
-//         ],
-//         implieds: [
-//             {
-//                 name: STRING,
-//                 line: NUMBER
-//             }
-//         ],
 //         urls: [
 //             STRING
 //         ],
@@ -150,7 +142,7 @@
 // with
 
 //     JSON.stringify(JSLINT.tree, [
-//         'value',  'arity', 'name',  'first',
+//         'string',  'arity', 'name',  'first',
 //         'second', 'third', 'block', 'else'
 //     ], 4));
 
@@ -164,13 +156,15 @@
 // The current option set is
 
 //     adsafe     true, if ADsafe rules should be enforced
-//     bitwise    true, if bitwise operators should not be allowed
+//     bitwise    true, if bitwise operators should be allowed
 //     browser    true, if the standard browser globals should be predefined
 //     cap        true, if upper case HTML should be allowed
+//     confusion  true, if types can be used inconsistently
 //     'continue' true, if the continuation statement should be tolerated
 //     css        true, if CSS workarounds should be tolerated
 //     debug      true, if debugger statements should be allowed
 //     devel      true, if logging should be allowed (console, alert, etc.)
+//     eqeq       true, if == should be allowed
 //     es5        true, if ES5 syntax should be allowed
 //     evil       true, if eval should be allowed
 //     forin      true, if for in statements need not filter
@@ -178,28 +172,29 @@
 //     indent     the indentation factor
 //     maxerr     the maximum number of errors to allow
 //     maxlen     the maximum length of a source line
-//     newcap     true, if constructor names must be capitalized
+//     newcap     true, if constructor names capitalization is ignored
 //     node       true, if Node.js globals should be predefined
-//     nomen      true, if names should be checked
+//     nomen      true, if names may have dangling _
 //     on         true, if HTML event handlers should be allowed
-//     onevar     true, if only one var statement per function should be allowed
 //     passfail   true, if the scan should stop on first error
-//     plusplus   true, if increment/decrement should not be allowed
-//     regexp     true, if the . should not be allowed in regexp literals
+//     plusplus   true, if increment/decrement should be allowed
+//     properties true, if all property names must be declared with /*properties*/
+//     regexp     true, if the . should be allowed in regexp literals
 //     rhino      true, if the Rhino environment globals should be predefined
-//     undef      true, if variables should be declared before used
+//     undef      true, if variables can be declared out of order
 //     unparam    true, if unused parameters should be tolerated
 //     safe       true, if use of some browser features should be restricted
-//     windows    true, if MS Windows-specific globals should be predefined
-//     strict     true, require the 'use strict'; pragma
+//     sloppy     true, if the 'use strict'; pragma is optional
 //     sub        true, if all forms of subscript notation are tolerated
-//     white      true, if strict whitespace rules apply
+//     vars       true, if multiple var statements per function should be allowed
+//     white      true, if sloppy whitespace is tolerated
 //     widget     true  if the Yahoo Widgets globals should be predefined
+//     windows    true, if MS Windows-specific globals should be predefined
 
 // For example:
 
 /*jslint
-    evil: true, nomen: false, onevar: false, regexp: false, strict: true
+    evil: true, nomen: true, regexp: true
 */
 
 // The properties directive declares an exclusive list of property names.
@@ -208,158 +203,201 @@
 
 // For example:
 
-/*properties "\b", "\t", "\n", "\f", "\r", "!=", "!==", "\"", "%",
-    "&", "'", "(begin)", "(breakage)", "(context)", "(error)",
-    "(global)", "(identifier)", "(line)", "(loopage)", "(name)", "(onevar)",
-    "(params)", "(scope)", "(statement)", "(token)", "(verb)", ")", "*",
-    "+", "-", "/", ";", "<", "<<", "<=", "==", "===", ">",
-    ">=", ">>", ">>>", ADSAFE, ActiveXObject, Array,
-    Boolean, Buffer, COM, CScript, Canvas, CustomAnimation, Date, Debug, E,
-    Enumerator, Error, EvalError, FadeAnimation, Flash, FormField, Frame,
-    Function, HotKey, Image, JSON, LN10, LN2, LOG10E, LOG2E, MAX_VALUE,
-    MIN_VALUE, Math, MenuItem, MoveAnimation, NEGATIVE_INFINITY, Number,
-    Object, Option, PI, POSITIVE_INFINITY, Point, RangeError, Rectangle,
-    ReferenceError, RegExp, ResizeAnimation, RotateAnimation, SQRT1_2,
-    SQRT2, ScrollBar, Storage, String, Style, SyntaxError, System, Text,
-    TextArea, Timer, TypeError, URIError, URL, VBArray, WScript, Web,
-    Window, XMLDOM, XMLHttpRequest, "\\", "^", __dirname, __filename, a,
-    a_function, a_label, a_not_allowed, a_not_defined, a_scope, abbr,
-    acronym, activeborder, activecaption, address, adsafe, adsafe_a,
-    adsafe_autocomplete, adsafe_bad_id, adsafe_div, adsafe_fragment,
-    adsafe_go, adsafe_html, adsafe_id, adsafe_id_go, adsafe_lib,
-    adsafe_lib_second, adsafe_missing_id, adsafe_name_a, adsafe_placement,
-    adsafe_prefix_a, adsafe_script, adsafe_source, adsafe_subscript_a,
-    adsafe_tag, alert, aliceblue, all, already_defined, and, animator,
-    antiquewhite, appleScript, applet, apply, approved, appworkspace, aqua,
-    aquamarine, area, arguments, arity, article, aside, assign,
-    assign_exception, assignment_function_expression, at, attribute_case_a,
-    audio, autocomplete, avoid_a, azure, b, background,
-    "background-attachment", "background-color", "background-image",
-    "background-position", "background-repeat", bad_assignment, bad_color_a,
-    bad_constructor, bad_entity, bad_html, bad_id_a, bad_in_a,
-    bad_invocation, bad_name_a, bad_new, bad_number, bad_operand, bad_type,
-    bad_url, bad_wrap, base, bdo, beep, beige, big, bisque, bitwise, black,
-    blanchedalmond, block, blockquote, blue, blueviolet, body, border,
-    "border-bottom", "border-bottom-color", "border-bottom-style",
-    "border-bottom-width", "border-collapse", "border-color", "border-left",
-    "border-left-color", "border-left-style", "border-left-width",
-    "border-right", "border-right-color", "border-right-style",
-    "border-right-width", "border-spacing", "border-style", "border-top",
-    "border-top-color", "border-top-style", "border-top-width",
-    "border-width", bottom, br, braille, brown, browser, burlywood, button,
-    buttonface, buttonhighlight, buttonshadow, buttontext, bytesToUIString,
-    c, cadetblue, call, callee, caller, canvas, cap, caption,
-    "caption-side", captiontext, center, charAt, charCodeAt, character,
-    chartreuse, chocolate, chooseColor, chooseFile, chooseFolder, cite,
-    clear, clearInterval, clearTimeout, clip, closeWidget, closure, cm,
-    code, col, colgroup, color, combine_var, command, comment, comments,
-    concat, conditional_assignment, confirm, confusing_a, confusing_regexp,
-    console, constructor, constructor_name_a, content, continue, control_a,
-    convertPathToHFS, convertPathToPlatform, coral, cornflowerblue,
-    cornsilk, "counter-increment", "counter-reset", create, crimson, css,
-    cursor, cyan, d, dangerous_comment, dangling_a, darkblue, darkcyan,
-    darkgoldenrod, darkgray, darkgreen, darkkhaki, darkmagenta,
-    darkolivegreen, darkorange, darkorchid, darkred, darksalmon,
-    darkseagreen, darkslateblue, darkslategray, darkturquoise, darkviolet,
-    data, datalist, dd, debug, decodeURI, decodeURIComponent, deeppink,
-    deepskyblue, defineClass, del, deleted, deserialize, details, devel,
-    dfn, dialog, dimgray, dir, direction, display, disrupt, div, dl,
-    document, dodgerblue, dt, duplicate_a, edge, edition, else, em, embed,
-    embossed, empty, "empty-cells", empty_block, empty_case, empty_class,
-    encodeURI, encodeURIComponent, entityify, errors, es5, escape, eval,
-    event, evidence, evil, ex, exception, exec, expected_a,
-    expected_a_at_b_c, expected_a_b, expected_a_b_from_c_d, expected_at_a,
-    expected_attribute_a, expected_attribute_value_a, expected_class_a,
-    expected_fraction_a, expected_id_a, expected_identifier_a,
-    expected_identifier_a_reserved, expected_lang_a, expected_linear_a,
-    expected_media_a, expected_name_a, expected_nonstandard_style_attribute,
-    expected_number_a, expected_operator_a, expected_percent_a,
-    expected_positive_a, expected_pseudo_a, expected_selector_a,
-    expected_small_a, expected_space_a_b, expected_string_a,
-    expected_style_attribute, expected_style_pattern, expected_tagname_a,
-    fieldset, figure, filesystem, filter, firebrick, first, float, floor,
-    floralwhite, focusWidget, font, "font-family", "font-size",
-    "font-size-adjust", "font-stretch", "font-style", "font-variant",
-    "font-weight", footer, for_if, forestgreen, forin, form, fragment,
-    frame, frames, frameset, from, fromCharCode, fuchsia, fud, funct,
-    function, function_block, function_eval, function_loop,
-    function_statement, function_strict, functions, g, gainsboro, gc,
-    ghostwhite, global, globals, gold, goldenrod, gray, graytext,
-    green, greenyellow, h1, h2, h3, h4, h5, h6, handheld, hasOwnProperty,
-    head, header, height, help, hgroup, highlight, highlighttext, history,
-    honeydew, hotpink, hr, "hta:application", html, html_confusion_a,
-    html_handlers, i, iTunes, id, identifier, identifier_function, iframe,
-    img, immed, implied_evil, implieds, in, inactiveborder, inactivecaption,
-    inactivecaptiontext, include, indent, indexOf, indianred, indigo,
-    infix_in, infobackground, infotext, init, input, ins, insecure_a,
-    isAlpha, isApplicationRunning, isArray, isDigit, isFinite, isNaN, ivory,
-    join, jslint, json, kbd, keygen, keys, khaki, konfabulatorVersion,
-    label, label_a_b, labeled, lang, lastIndexOf, lavender, lavenderblush,
-    lawngreen, lbp, leading_decimal_a, led, left, legend, lemonchiffon,
-    length, "letter-spacing", li, lib, lightblue, lightcoral, lightcyan,
-    lightgoldenrodyellow, lightgreen, lightpink, lightsalmon, lightseagreen,
-    lightskyblue, lightslategray, lightsteelblue, lightyellow, lime,
-    limegreen, line, "line-height", linen, link, "list-style",
-    "list-style-image", "list-style-position", "list-style-type", load,
-    loadClass, localStorage, location, log, m, magenta, map, margin,
-    "margin-bottom", "margin-left", "margin-right", "margin-top", mark,
-    "marker-offset", maroon, match, "max-height", "max-width", maxerr,
-    maxlen, md5, mediumaquamarine, mediumblue, mediumorchid, mediumpurple,
-    mediumseagreen, mediumslateblue, mediumspringgreen, mediumturquoise,
-    mediumvioletred, member, menu, menutext, message, meta, meter,
-    midnightblue, "min-height", "min-width", mintcream, missing_a,
-    missing_a_after_b, missing_option, missing_property, missing_space_a_b,
-    missing_url, missing_use_strict, mistyrose, mixed, mm, moccasin, mode,
-    module, move_invocation, move_var, name, name_function, nav,
-    navajowhite, navigator, navy, nested_comment, newcap, next, node,
-    noframes, nomen, noscript, not, not_a_constructor, not_a_defined,
-    not_a_function, not_a_label, not_a_scope, not_greater, nud, object, ol,
-    oldlace, olive, olivedrab, on, onevar, opacity, open, openURL, opera,
-    optgroup, option, orange, orangered, orchid, outer, outline,
-    "outline-color", "outline-style", "outline-width", output, overflow,
-    "overflow-x", "overflow-y", p, padding, "padding-bottom",
-    "padding-left", "padding-right", "padding-top", "page-break-after",
-    "page-break-before", palegoldenrod, palegreen, paleturquoise,
-    palevioletred, papayawhip, param, parameter_a_get_b, parameter_set_a,
-    paren, parent, parseFloat, parseInt, passfail, pc, peachpuff, peru,
-    pink, play, plum, plusplus, pop, popupMenu, position, postscript,
-    powderblue, pre, predef, preferenceGroups, preferences, prev, print,
-    process, progress, projection, prompt, prototype, pt, purple, push, px,
-    q, querystring, quit, quote, quotes, radix, random, range, raw,
-    readFile, readUrl, read_only, reason, red, redefinition_a, regexp,
-    reloadWidget, replace, report, require, reserved, reserved_a,
-    resolvePath, resumeUpdates, rhino, right, rosybrown, royalblue, rp, rt,
-    ruby, runCommand, runCommandInBg, saddlebrown, safe, salmon, samp,
-    sandybrown, saveAs, savePreferences, scanned_a_b, screen, script,
-    scrollbar, seagreen, seal, search, seashell, second, section, select,
-    serialize, sessionStorage, setInterval, setTimeout, shift,
-    showWidgetPreferences, sienna, silver, skyblue, slash_equal, slateblue,
-    slategray, sleep, slice, small, snow, sort, source, span, spawn, speak,
-    speech, split, springgreen, src, stack, statement_block, steelblue,
-    stopping, strange_loop, strict, strong, style, styleproperty, sub,
-    subscript, substr, sup, supplant, suppressUpdates, sync, system, table,
-    "table-layout", tag_a_in_b, tan, tbody, td, teal, tellWidget, test,
-    "text-align", "text-decoration", "text-indent", "text-shadow",
-    "text-transform", textarea, tfoot, th, thead, third, thistle,
-    threeddarkshadow, threedface, threedhighlight, threedlightshadow,
-    threedshadow, thru, time, title, toLowerCase, toString, toUpperCase,
-    toint32, token, tomato, too_long, too_many, top, tr, trailing_decimal_a,
-    tree, tt, tty, turquoise, tv, type, typeof, u, ul, unclosed,
-    unclosed_comment, unclosed_regexp, undef, unescape, unescaped_a,
-    unexpected_a, unexpected_char_a_b, unexpected_comment,
-    unexpected_property_a, unexpected_space_a_b, "unicode-bidi",
-    unnecessary_initialize, unnecessary_use, unreachable_a_b,
-    unrecognized_style_attribute_a, unrecognized_tag_a, unparam, unsafe, unused,
-    unwatch, updateNow, url, urls, use_array, use_braces, use_object, use_param,
-    used_before_a, util, value, valueOf, var, var_a_not, version,
-    "vertical-align", video, violet, visibility, was, watch,
-    weird_assignment, weird_condition, weird_new, weird_program,
-    weird_relation, weird_ternary, wheat, white, "white-space", whitesmoke,
-    widget, width, window, windowframe, windows, windowtext, "word-spacing",
-    "word-wrap", wrap, wrap_immediate, wrap_regexp, write_is_wrong,
-    yahooCheckLogin, yahooLogin, yahooLogout, yellow, yellowgreen,
-    "z-index", "|", "~"
- */
+/*properties
+    '\b': string, '\t': string, '\n': string, '\f': string, '\r': string,
+    '!=': boolean, '!==': boolean, '"': string, '%': boolean, '\'': string,
+    '(begin)', '(breakage)': number, '(complexity)', '(confusion)': boolean,
+    '(context)': object, '(error)', '(identifier)', '(line)': number,
+    '(loopage)': number, '(name)', '(old_property_type)', '(params)',
+    '(scope)': object, '(token)', '(vars)', '(verb)', '*': boolean,
+    '+': boolean, '-': boolean, '/': *, '<': boolean, '<=': boolean,
+    '==': boolean, '===': boolean, '>': boolean, '>=': boolean,
+    ADSAFE: boolean, Array, Date, E: string, Function, LN10: string,
+    LN2: string, LOG10E: string, LOG2E: string, MAX_VALUE: string,
+    MIN_VALUE: string, NEGATIVE_INFINITY: string, Object, PI: string,
+    POSITIVE_INFINITY: string, SQRT1_2: string, SQRT2: string, '\\': string,
+    a: object, a_label: string, a_not_allowed: string, a_not_defined: string,
+    a_scope: string, abbr: object, acronym: object, address: object, adsafe,
+    adsafe_a: string, adsafe_autocomplete: string, adsafe_bad_id: string,
+    adsafe_div: string, adsafe_fragment: string, adsafe_go: string,
+    adsafe_html: string, adsafe_id: string, adsafe_id_go: string,
+    adsafe_lib: string, adsafe_lib_second: string, adsafe_missing_id: string,
+    adsafe_name_a: string, adsafe_placement: string, adsafe_prefix_a: string,
+    adsafe_script: string, adsafe_source: string, adsafe_subscript_a: string,
+    adsafe_tag: string, all: boolean, already_defined: string, and: string,
+    applet: object, apply: string, approved: array, area: object,
+    arity: string, article: object, aside: object, assign: boolean,
+    assign_exception: string, assignment_function_expression: string,
+    at: number, attribute_case_a: string, audio: object, autocomplete: string,
+    avoid_a: string, b: *, background: array, 'background-attachment': array,
+    'background-color': array, 'background-image': array,
+    'background-position': array, 'background-repeat': array,
+    bad_assignment: string, bad_color_a: string, bad_constructor: string,
+    bad_entity: string, bad_html: string, bad_id_a: string, bad_in_a: string,
+    bad_invocation: string, bad_name_a: string, bad_new: string,
+    bad_number: string, bad_operand: string, bad_style: string,
+    bad_type: string, bad_url_a: string, bad_wrap: string, base: object,
+    bdo: object, big: object, bind: string, bitwise: boolean, block: array,
+    blockquote: object, body: object, border: array, 'border-bottom': array,
+    'border-bottom-color', 'border-bottom-left-radius',
+    'border-bottom-right-radius', 'border-bottom-style': array,
+    'border-bottom-width', 'border-collapse': array, 'border-color': array,
+    'border-left': array, 'border-left-color', 'border-left-style': array,
+    'border-left-width', 'border-radius', 'border-right': array,
+    'border-right-color', 'border-right-style': array, 'border-right-width',
+    'border-spacing': array, 'border-style': array, 'border-top': array,
+    'border-top-color', 'border-top-left-radius', 'border-top-right-radius',
+    'border-top-style': array, 'border-top-width', 'border-width': array,
+    bottom: array, br: object, braille: boolean, browser: boolean,
+    button: object, c, call: string, canvas: object, cap, caption: object,
+    'caption-side': array, ceil: string, center: object, charAt: *,
+    charCodeAt: *, character, cite: object, clear: array, clip: array, closure,
+    cm: boolean, code: object, col: object, colgroup: object, color,
+    combine_var: string, command: object, concat: string,
+    conditional_assignment: string, confusing_a: string,
+    confusing_regexp: string, confusion: boolean, constructor: string,
+    constructor_name_a: string, content: array, continue, control_a: string,
+    'counter-increment': array, 'counter-reset': array, create: *, css: string,
+    cursor: array, d, dangerous_comment: string, dangling_a: string,
+    data: function object, datalist: object, dd: object, debug,
+    defineProperties: string, defineProperty: string, del: object,
+    deleted: string, details: object, devel: boolean, dfn: object,
+    dialog: object, dir: object, direction: array, display: array,
+    disrupt: boolean, div: object, dl: object, dt: object, duplicate_a: string,
+    edge: string, edition: string, else, em: *, embed: object,
+    embossed: boolean, empty: boolean, 'empty-cells': array,
+    empty_block: string, empty_case: string, empty_class: string,
+    entityify: function, eqeq, errors: array, es5: string, eval, every: string,
+    evidence, evil: string, ex: boolean, exception, exec: *,
+    expected_a: string, expected_a_at_b_c: string, expected_a_b: string,
+    expected_a_b_from_c_d: string, expected_at_a: string,
+    expected_attribute_a: string, expected_attribute_value_a: string,
+    expected_class_a: string, expected_fraction_a: string,
+    expected_id_a: string, expected_identifier_a: string,
+    expected_identifier_a_reserved: string, expected_lang_a: string,
+    expected_linear_a: string, expected_media_a: string,
+    expected_name_a: string, expected_nonstandard_style_attribute: string,
+    expected_number_a: string, expected_operator_a: string,
+    expected_percent_a: string, expected_positive_a: string,
+    expected_pseudo_a: string, expected_selector_a: string,
+    expected_small_a: string, expected_space_a_b: string,
+    expected_string_a: string, expected_style_attribute: string,
+    expected_style_pattern: string, expected_tagname_a: string,
+    expected_type_a: string, f: string, fieldset: object, figure: object,
+    filter: *, first: *, flag, float: array, floor: *, font: *, 'font-family',
+    'font-size': array, 'font-size-adjust': array, 'font-stretch': array,
+    'font-style': array, 'font-variant': array, 'font-weight': array,
+    footer: object, for, forEach: *, for_if: string, forin, form: object,
+    fragment, frame: object, frameset: object, freeze: string, from: number,
+    fromCharCode: function, fud: function, funct: object, function,
+    function_block: string, function_eval: string, function_loop: string,
+    function_statement: string, function_strict: string, functions: array,
+    getDate: string, getDay: string, getFullYear: string, getHours: string,
+    getMilliseconds: string, getMinutes: string, getMonth: string,
+    getOwnPropertyDescriptor: string, getOwnPropertyNames: string,
+    getPrototypeOf: string, getSeconds: string, getTime: string,
+    getTimezoneOffset: string, getUTCDate: string, getUTCDay: string,
+    getUTCFullYear: string, getUTCHours: string, getUTCMilliseconds: string,
+    getUTCMinutes: string, getUTCMonth: string, getUTCSeconds: string,
+    getYear: string, global, globals, h1: object, h2: object, h3: object,
+    h4: object, h5: object, h6: object, handheld: boolean, hasOwnProperty: *,
+    head: object, header: object, height: array, hgroup: object, hr: object,
+    'hta:application': object, html: *, html_confusion_a: string,
+    html_handlers: string, i: object, id: string, identifier: boolean,
+    identifier_function: string, iframe: object, img: object, immed: boolean,
+    implied_evil: string, in, indent: number, indexOf: *, infix_in: string,
+    init: function, input: object, ins: object, insecure_a: string,
+    isAlpha: function, isArray: function boolean, isDigit: function,
+    isExtensible: string, isFrozen: string, isNaN: string,
+    isPrototypeOf: string, isSealed: string, join: *, jslint: function boolean,
+    json: boolean, kbd: object, keygen: object, keys: *, label: object,
+    label_a_b: string, labeled: boolean, lang: string, lastIndex: string,
+    lastIndexOf: *, lbp: number, leading_decimal_a: string, led: function,
+    left: array, legend: object, length: *, 'letter-spacing': array,
+    li: object, lib: boolean, line: number, 'line-height': array, link: object,
+    'list-style': array, 'list-style-image': array,
+    'list-style-position': array, 'list-style-type': array, map: *,
+    margin: array, 'margin-bottom', 'margin-left', 'margin-right',
+    'margin-top', mark: object, 'marker-offset': array, match: function,
+    'max-height': array, 'max-width': array, maxerr: number,
+    maxlen: number, member: object, menu: object, message, meta: object,
+    meter: object, 'min-height': function, 'min-width': function,
+    missing_a: string, missing_a_after_b: string, missing_option: string,
+    missing_property: string, missing_space_a_b: string, missing_url: string,
+    missing_use_strict: string, mixed: string, mm: boolean, mode: string,
+    move_invocation: string, move_var: string, n: string, name: string,
+    name_function: string, nav: object, nested_comment: string,
+    newcap: boolean, node: boolean, noframes: object, nomen, noscript: object,
+    not: string, not_a_constructor: string, not_a_defined: string,
+    not_a_function: string, not_a_label: string, not_a_scope: string,
+    not_greater: string, now: string, nud: function, number: number,
+    object: object, ol: object, on, opacity, open: boolean, optgroup: object,
+    option: object, outer: regexp, outline: array, 'outline-color': array,
+    'outline-style': array, 'outline-width', output: object, overflow: array,
+    'overflow-x': array, 'overflow-y': array, p: object, padding: array,
+    'padding-bottom': function, 'padding-left': function,
+    'padding-right': function, 'padding-top': function,
+    'page-break-after': array, 'page-break-before': array, param: object,
+    parameter_a_get_b: string, parameter_set_a: string, params: array,
+    paren: boolean, parent: string, parse: string, passfail, pc: boolean,
+    plusplus, pop: *, position: array, postscript: boolean, pre: object,
+    predef, preventExtensions: string, print: boolean, progress: object,
+    projection: boolean, properties: boolean, propertyIsEnumerable: string,
+    prototype: string, pt: boolean, push: *, px: boolean, q: object, quote,
+    quotes: array, r: string, radix: string, range: function, raw,
+    read_only: string, reason, redefinition_a: string, reduce: string,
+    reduceRight: string, regexp, replace: function, report: function,
+    reserved: boolean, reserved_a: string, reverse: string, rhino: boolean,
+    right: array, rp: object, rt: object, ruby: object, safe: boolean,
+    samp: object, scanned_a_b: string, screen: boolean, script: object,
+    seal: string, search: function, second: *, section: object, select: object,
+    setDate: string, setDay: string, setFullYear: string, setHours: string,
+    setMilliseconds: string, setMinutes: string, setMonth: string,
+    setSeconds: string, setTime: string, setTimezoneOffset: string,
+    setUTCDate: string, setUTCDay: string, setUTCFullYear: string,
+    setUTCHours: string, setUTCMilliseconds: string, setUTCMinutes: string,
+    setUTCMonth: string, setUTCSeconds: string, setYear: string, shift: *,
+    slash_equal: string, slice: string, sloppy, small: object, some: string,
+    sort: *, source: object, span: object, speech: boolean, splice: string,
+    split: function, src, statement_block: string, stopping: string,
+    strange_loop: string, strict: string, string: string, stringify: string,
+    strong: object, style: *, styleproperty: regexp, sub: object,
+    subscript: string, substr: *, substring: string, sup: object,
+    supplant: function, t: string, table: object, 'table-layout': array,
+    tag_a_in_b: string, tbody: object, td: object, test: *,
+    'text-align': array, 'text-decoration': array, 'text-indent': function,
+    'text-shadow': array, 'text-transform': array, textarea: object,
+    tfoot: object, th: object, thead: object, third: array, thru: number,
+    time: object, title: object, toDateString: string, toExponential: string,
+    toFixed: string, toISOString: string, toJSON: string,
+    toLocaleDateString: string, toLocaleLowerCase: string,
+    toLocaleString: string, toLocaleTimeString: string,
+    toLocaleUpperCase: string, toLowerCase: *, toPrecision: string,
+    toString: function, toTimeString: string, toUTCString: string,
+    toUpperCase: *, token: function, too_long: string, too_many: string,
+    top: array, tr: object, trailing_decimal_a: string, tree: string,
+    trim: string, tt: object, tty: boolean, tv: boolean, type: string,
+    type_confusion_a_b: string, u: object, ul: object, unclosed: string,
+    unclosed_comment: string, unclosed_regexp: string, undef: boolean,
+    undefined, unescaped_a: string, unexpected_a: string,
+    unexpected_char_a_b: string, unexpected_comment: string,
+    unexpected_property_a: string, unexpected_space_a_b: string,
+    'unicode-bidi': array, unnecessary_initialize: string,
+    unnecessary_use: string, unparam, unreachable_a_b: string,
+    unrecognized_style_attribute_a: string, unrecognized_tag_a: string,
+    unsafe: string, unshift: string, unused: array, url: string, urls: array,
+    use_array: string, use_braces: string, use_charAt: string,
+    use_object: string, use_or: string, use_param: string,
+    used_before_a: string, valueOf: string, var: object, var_a_not: string,
+    vars, 'vertical-align': array, video: object, visibility: array,
+    warn: boolean, was: object, weird_assignment: string,
+    weird_condition: string, weird_new: string, weird_program: string,
+    weird_relation: string, weird_ternary: string, white: boolean,
+    'white-space': array, widget: boolean, width: array, windows: boolean,
+    'word-spacing': array, 'word-wrap': array, wrap: boolean,
+    wrap_immediate: string, wrap_regexp: string, write_is_wrong: string,
+    writeable: boolean, 'z-index': array
+*/
 
 // The global directive is used to declare global variables that can
 // be accessed by the program. If a declaration is true, then the variable
@@ -373,25 +411,19 @@
 var JSLINT = (function () {
     'use strict';
 
+    function array_to_object(array, value) {
+
+// Make an object from an array of keys and a common value.
+
+        var i, length = array.length, object = {};
+        for (i = 0; i < length; i += 1) {
+            object[array[i]] = value;
+        }
+        return object;
+    }
+
+
     var adsafe_id,      // The widget's ADsafe id.
-        adsafe_infix = {
-            '-': true,
-            '*': true,
-            '/': true,
-            '%': true,
-            '&': true,
-            '|': true,
-            '^': true,
-            '<<': true,
-            '>>': true,
-            '>>>': true
-        },
-        adsafe_prefix = {
-            '-': true,
-            '+': true,
-            '~': true,
-            'typeof': true
-        },
         adsafe_may,     // The widget may load approved scripts.
         adsafe_top,     // At the top of the widget script.
         adsafe_went,    // ADSAFE.go has been called.
@@ -418,55 +450,29 @@ var JSLINT = (function () {
 
 // These are property names that should not be permitted in the safe subset.
 
-        banned = {
-            'arguments' : true,
-            callee      : true,
-            caller      : true,
-            constructor : true,
-            'eval'      : true,
-            prototype   : true,
-            stack       : true,
-            unwatch     : true,
-            valueOf     : true,
-            watch       : true
-        },
+        banned = array_to_object([
+            'arguments', 'callee', 'caller', 'constructor', 'eval', 'prototype',
+            'stack', 'unwatch', 'valueOf', 'watch'
+        ], true),
         begin,          // The root token
 
 // browser contains a set of global names that are commonly provided by a
 // web browser environment.
 
-        browser = {
-            clearInterval  : false,
-            clearTimeout   : false,
-            document       : false,
-            event          : false,
-            frames         : false,
-            history        : false,
-            Image          : false,
-            localStorage   : false,
-            location       : false,
-            name           : false,
-            navigator      : false,
-            Option         : false,
-            parent         : false,
-            screen         : false,
-            sessionStorage : false,
-            setInterval    : false,
-            setTimeout     : false,
-            Storage        : false,
-            window         : false,
-            XMLHttpRequest : false
-        },
+        browser = array_to_object([
+            'clearInterval', 'clearTimeout', 'document', 'event', 'frames',
+            'history', 'Image', 'localStorage', 'location', 'name', 'navigator',
+            'Option', 'parent', 'screen', 'sessionStorage', 'setInterval',
+            'setTimeout', 'Storage', 'window', 'XMLHttpRequest'
+        ], false),
 
 // bundle contains the text messages.
 
         bundle = {
-            a_function: "'{a}' is a function.",
             a_label: "'{a}' is a statement label.",
             a_not_allowed: "'{a}' is not allowed.",
             a_not_defined: "'{a}' is not defined.",
             a_scope: "'{a}' used out of scope.",
-            adsafe: "ADsafe violation.",
             adsafe_a: "ADsafe violation: '{a}'.",
             adsafe_autocomplete: "ADsafe autocomplete violation.",
             adsafe_bad_id: "ADSAFE violation: bad id.",
@@ -506,8 +512,9 @@ var JSLINT = (function () {
             bad_new: "Do not use 'new' for side effects.",
             bad_number: "Bad number '{a}'.",
             bad_operand: "Bad operand.",
+            bad_style: "Bad style.",
             bad_type: "Bad type.",
-            bad_url: "Bad url string.",
+            bad_url_a: "Bad url '{a}'.",
             bad_wrap: "Do not wrap function literals in parens unless they " +
                 "are to be immediately invoked.",
             combine_var: "Combine this with the previous 'var' statement.",
@@ -556,12 +563,13 @@ var JSLINT = (function () {
             expected_positive_a: "Expected a positive number and instead saw '{a}'",
             expected_pseudo_a: "Expected a pseudo, and instead saw :{a}.",
             expected_selector_a: "Expected a CSS selector, and instead saw {a}.",
-            expected_small_a: "Expected a small number and instead saw '{a}'",
+            expected_small_a: "Expected a small positive integer and instead saw '{a}'",
             expected_space_a_b: "Expected exactly one space between '{a}' and '{b}'.",
             expected_string_a: "Expected a string and instead saw {a}.",
             expected_style_attribute: "Excepted a style attribute, and instead saw '{a}'.",
             expected_style_pattern: "Expected a style pattern, and instead saw '{a}'.",
             expected_tagname_a: "Expected a tagName, and instead saw {a}.",
+            expected_type_a: "Expected a type, and instead saw {a}.",
             for_if: "The body of a for in should be wrapped in an if " +
                 "statement to filter unwanted properties from the prototype.",
             function_block: "Function statements should not be placed in blocks. " +
@@ -623,6 +631,7 @@ var JSLINT = (function () {
             trailing_decimal_a: "A trailing decimal point can be confused " +
                 "with a dot: '.{a}'.",
             type: "type is unnecessary.",
+            type_confusion_a_b: "Type confusion: {a} and {b}.",
             unclosed: "Unclosed string.",
             unclosed_comment: "Unclosed comment.",
             unclosed_regexp: "Unclosed regular expression.",
@@ -642,7 +651,9 @@ var JSLINT = (function () {
             url: "JavaScript URL.",
             use_array: "Use the array literal notation [].",
             use_braces: "Spaces are hard to count. Use {{a}}.",
+            use_charAt: "Use the charAt method.",
             use_object: "Use the object literal notation {}.",
+            use_or: "Use the || operator.",
             use_param: "Use a named parameter.",
             used_before_a: "'{a}' was used before it was defined.",
             var_a_not: "Variable {a} was not declared correctly.",
@@ -663,176 +674,46 @@ var JSLINT = (function () {
         css_attribute_data,
         css_any,
 
-        css_colorData = {
-            "aliceblue"             : true,
-            "antiquewhite"          : true,
-            "aqua"                  : true,
-            "aquamarine"            : true,
-            "azure"                 : true,
-            "beige"                 : true,
-            "bisque"                : true,
-            "black"                 : true,
-            "blanchedalmond"        : true,
-            "blue"                  : true,
-            "blueviolet"            : true,
-            "brown"                 : true,
-            "burlywood"             : true,
-            "cadetblue"             : true,
-            "chartreuse"            : true,
-            "chocolate"             : true,
-            "coral"                 : true,
-            "cornflowerblue"        : true,
-            "cornsilk"              : true,
-            "crimson"               : true,
-            "cyan"                  : true,
-            "darkblue"              : true,
-            "darkcyan"              : true,
-            "darkgoldenrod"         : true,
-            "darkgray"              : true,
-            "darkgreen"             : true,
-            "darkkhaki"             : true,
-            "darkmagenta"           : true,
-            "darkolivegreen"        : true,
-            "darkorange"            : true,
-            "darkorchid"            : true,
-            "darkred"               : true,
-            "darksalmon"            : true,
-            "darkseagreen"          : true,
-            "darkslateblue"         : true,
-            "darkslategray"         : true,
-            "darkturquoise"         : true,
-            "darkviolet"            : true,
-            "deeppink"              : true,
-            "deepskyblue"           : true,
-            "dimgray"               : true,
-            "dodgerblue"            : true,
-            "firebrick"             : true,
-            "floralwhite"           : true,
-            "forestgreen"           : true,
-            "fuchsia"               : true,
-            "gainsboro"             : true,
-            "ghostwhite"            : true,
-            "gold"                  : true,
-            "goldenrod"             : true,
-            "gray"                  : true,
-            "green"                 : true,
-            "greenyellow"           : true,
-            "honeydew"              : true,
-            "hotpink"               : true,
-            "indianred"             : true,
-            "indigo"                : true,
-            "ivory"                 : true,
-            "khaki"                 : true,
-            "lavender"              : true,
-            "lavenderblush"         : true,
-            "lawngreen"             : true,
-            "lemonchiffon"          : true,
-            "lightblue"             : true,
-            "lightcoral"            : true,
-            "lightcyan"             : true,
-            "lightgoldenrodyellow"  : true,
-            "lightgreen"            : true,
-            "lightpink"             : true,
-            "lightsalmon"           : true,
-            "lightseagreen"         : true,
-            "lightskyblue"          : true,
-            "lightslategray"        : true,
-            "lightsteelblue"        : true,
-            "lightyellow"           : true,
-            "lime"                  : true,
-            "limegreen"             : true,
-            "linen"                 : true,
-            "magenta"               : true,
-            "maroon"                : true,
-            "mediumaquamarine"      : true,
-            "mediumblue"            : true,
-            "mediumorchid"          : true,
-            "mediumpurple"          : true,
-            "mediumseagreen"        : true,
-            "mediumslateblue"       : true,
-            "mediumspringgreen"     : true,
-            "mediumturquoise"       : true,
-            "mediumvioletred"       : true,
-            "midnightblue"          : true,
-            "mintcream"             : true,
-            "mistyrose"             : true,
-            "moccasin"              : true,
-            "navajowhite"           : true,
-            "navy"                  : true,
-            "oldlace"               : true,
-            "olive"                 : true,
-            "olivedrab"             : true,
-            "orange"                : true,
-            "orangered"             : true,
-            "orchid"                : true,
-            "palegoldenrod"         : true,
-            "palegreen"             : true,
-            "paleturquoise"         : true,
-            "palevioletred"         : true,
-            "papayawhip"            : true,
-            "peachpuff"             : true,
-            "peru"                  : true,
-            "pink"                  : true,
-            "plum"                  : true,
-            "powderblue"            : true,
-            "purple"                : true,
-            "red"                   : true,
-            "rosybrown"             : true,
-            "royalblue"             : true,
-            "saddlebrown"           : true,
-            "salmon"                : true,
-            "sandybrown"            : true,
-            "seagreen"              : true,
-            "seashell"              : true,
-            "sienna"                : true,
-            "silver"                : true,
-            "skyblue"               : true,
-            "slateblue"             : true,
-            "slategray"             : true,
-            "snow"                  : true,
-            "springgreen"           : true,
-            "steelblue"             : true,
-            "tan"                   : true,
-            "teal"                  : true,
-            "thistle"               : true,
-            "tomato"                : true,
-            "turquoise"             : true,
-            "violet"                : true,
-            "wheat"                 : true,
-            "white"                 : true,
-            "whitesmoke"            : true,
-            "yellow"                : true,
-            "yellowgreen"           : true,
+        css_colorData = array_to_object([
+            "aliceblue", "antiquewhite", "aqua", "aquamarine", "azure", "beige",
+            "bisque", "black", "blanchedalmond", "blue", "blueviolet", "brown",
+            "burlywood", "cadetblue", "chartreuse", "chocolate", "coral",
+            "cornflowerblue", "cornsilk", "crimson", "cyan", "darkblue",
+            "darkcyan", "darkgoldenrod", "darkgray", "darkgreen", "darkkhaki",
+            "darkmagenta", "darkolivegreen", "darkorange", "darkorchid",
+            "darkred", "darksalmon", "darkseagreen", "darkslateblue",
+            "darkslategray", "darkturquoise", "darkviolet", "deeppink",
+            "deepskyblue", "dimgray", "dodgerblue", "firebrick", "floralwhite",
+            "forestgreen", "fuchsia", "gainsboro", "ghostwhite", "gold",
+            "goldenrod", "gray", "green", "greenyellow", "honeydew", "hotpink",
+            "indianred", "indigo", "ivory", "khaki", "lavender",
+            "lavenderblush", "lawngreen", "lemonchiffon", "lightblue",
+            "lightcoral", "lightcyan", "lightgoldenrodyellow", "lightgreen",
+            "lightpink", "lightsalmon", "lightseagreen", "lightskyblue",
+            "lightslategray", "lightsteelblue", "lightyellow", "lime",
+            "limegreen", "linen", "magenta", "maroon", "mediumaquamarine",
+            "mediumblue", "mediumorchid", "mediumpurple", "mediumseagreen",
+            "mediumslateblue", "mediumspringgreen", "mediumturquoise",
+            "mediumvioletred", "midnightblue", "mintcream", "mistyrose",
+            "moccasin", "navajowhite", "navy", "oldlace", "olive", "olivedrab",
+            "orange", "orangered", "orchid", "palegoldenrod", "palegreen",
+            "paleturquoise", "palevioletred", "papayawhip", "peachpuff",
+            "peru", "pink", "plum", "powderblue", "purple", "red", "rosybrown",
+            "royalblue", "saddlebrown", "salmon", "sandybrown", "seagreen",
+            "seashell", "sienna", "silver", "skyblue", "slateblue", "slategray",
+            "snow", "springgreen", "steelblue", "tan", "teal", "thistle",
+            "tomato", "turquoise", "violet", "wheat", "white", "whitesmoke",
+            "yellow", "yellowgreen",
 
-            "activeborder"          : true,
-            "activecaption"         : true,
-            "appworkspace"          : true,
-            "background"            : true,
-            "buttonface"            : true,
-            "buttonhighlight"       : true,
-            "buttonshadow"          : true,
-            "buttontext"            : true,
-            "captiontext"           : true,
-            "graytext"              : true,
-            "highlight"             : true,
-            "highlighttext"         : true,
-            "inactiveborder"        : true,
-            "inactivecaption"       : true,
-            "inactivecaptiontext"   : true,
-            "infobackground"        : true,
-            "infotext"              : true,
-            "menu"                  : true,
-            "menutext"              : true,
-            "scrollbar"             : true,
-            "threeddarkshadow"      : true,
-            "threedface"            : true,
-            "threedhighlight"       : true,
-            "threedlightshadow"     : true,
-            "threedshadow"          : true,
-            "window"                : true,
-            "windowframe"           : true,
-            "windowtext"            : true
-        },
+            "activeborder", "activecaption", "appworkspace", "background",
+            "buttonface", "buttonhighlight", "buttonshadow", "buttontext",
+            "captiontext", "graytext", "highlight", "highlighttext",
+            "inactiveborder", "inactivecaption", "inactivecaptiontext",
+            "infobackground", "infotext", "menu", "menutext", "scrollbar",
+            "threeddarkshadow", "threedface", "threedhighlight",
+            "threedlightshadow", "threedshadow", "window", "windowframe",
+            "windowtext"
+        ], true),
 
         css_border_style,
         css_break,
@@ -852,15 +733,21 @@ var JSLINT = (function () {
         css_media,
         css_overflow,
 
-        devel = {
-            alert           : false,
-            confirm         : false,
-            console         : false,
-            Debug           : false,
-            opera           : false,
-            prompt          : false
+        descapes = {
+            'b': '\b',
+            't': '\t',
+            'n': '\n',
+            'f': '\f',
+            'r': '\r',
+            '"': '"',
+            '/': '/',
+            '\\': '\\'
         },
 
+        devel = array_to_object([
+            'alert', 'confirm', 'console', 'Debug', 'opera', 'prompt', 'WSH'
+        ], false),
+        directive,
         escapes = {
             '\b': '\\b',
             '\t': '\\t',
@@ -873,14 +760,19 @@ var JSLINT = (function () {
             '\\': '\\\\'
         },
 
-        funct,          // The current function
+        funct,          // The current function, including the labels used in
+                        // the function, as well as (breakage), (complexity),
+                        // (context), (loopage), (name), (params), (token),
+                        // (vars), (verb)
 
         functionicity = [
-            'closure', 'exception', 'global', 'label', 'outer', 'unused', 'var'
+            'closure', 'exception', 'global', 'label', 'outer', 'undef',
+            'unused', 'var'
         ],
 
         functions,      // All of the functions
-        global,         // The global scope
+        global_funct,   // The global body
+        global_scope,   // The global scope
         html_tag = {
             a:        {},
             abbr:     {},
@@ -1000,128 +892,191 @@ var JSLINT = (function () {
         },
 
         ids,            // HTML ids
-        implied,        // Implied globals
         in_block,
         indent,
+//         infer_statement,// Inference rules for statements
+        is_type = array_to_object([
+            '*', 'array', 'boolean', 'function', 'number', 'object',
+            'regexp', 'string'
+        ], true),
+        itself,         // JSLint itself
+        jslint_limit = {
+            indent: 10,
+            maxerr: 1000,
+            maxlen: 256
+        },
         json_mode,
+        lex,            // the tokenizer
         lines,
         lookahead,
         member,
-        node = {
-            Buffer       : false,
-            clearInterval: false,
-            clearTimeout : false,
-            console      : false,
-            global       : false,
-            module       : false,
-            process      : false,
-            querystring  : false,
-            require      : false,
-            setInterval  : false,
-            setTimeout   : false,
-            util         : false,
-            __filename   : false,
-            __dirname    : false
-        },
-        numbery = {
-            indexOf     : true,
-            lastIndexOf : true,
-            search      : true
-        },
-        properties,
+        node = array_to_object([
+            'Buffer', 'clearInterval', 'clearTimeout', 'console', 'exports',
+            'global', 'module', 'process', 'querystring', 'require',
+            'setInterval', 'setTimeout', '__dirname', '__filename'
+        ], false),
+        node_js,
+        numbery = array_to_object(['indexOf', 'lastIndexOf', 'search'], true),
         next_token,
-        older_token,
         option,
         predefined,     // Global variables defined by option
         prereg,
         prev_token,
-        regexp_flag = {
-            g: true,
-            i: true,
-            m: true
+        property_type,
+        regexp_flag = array_to_object(['g', 'i', 'm'], true),
+        return_this = function return_this() {
+            return this;
         },
-        rhino = {
-            defineClass : false,
-            deserialize : false,
-            gc          : false,
-            help        : false,
-            load        : false,
-            loadClass   : false,
-            print       : false,
-            quit        : false,
-            readFile    : false,
-            readUrl     : false,
-            runCommand  : false,
-            seal        : false,
-            serialize   : false,
-            spawn       : false,
-            sync        : false,
-            toint32     : false,
-            version     : false
-        },
+        rhino = array_to_object([
+            'defineClass', 'deserialize', 'gc', 'help', 'load', 'loadClass',
+            'print', 'quit', 'readFile', 'readUrl', 'runCommand', 'seal',
+            'serialize', 'spawn', 'sync', 'toint32', 'version'
+        ], false),
 
-        scope,      // The current scope
-        semicolon_coda = {
-            ';' : true,
-            '"' : true,
-            '\'': true,
-            ')' : true
-        },
+        scope,      // An object containing an object for each variable in scope
+        semicolon_coda = array_to_object([';', '"', '\'', ')'], true),
         src,
         stack,
 
 // standard contains the global names that are provided by the
 // ECMAScript standard.
 
-        standard = {
-            Array               : false,
-            Boolean             : false,
-            Date                : false,
-            decodeURI           : false,
-            decodeURIComponent  : false,
-            encodeURI           : false,
-            encodeURIComponent  : false,
-            Error               : false,
-            'eval'              : false,
-            EvalError           : false,
-            Function            : false,
-            hasOwnProperty      : false,
-            isFinite            : false,
-            isNaN               : false,
-            JSON                : false,
-            Math                : false,
-            Number              : false,
-            Object              : false,
-            parseInt            : false,
-            parseFloat          : false,
-            RangeError          : false,
-            ReferenceError      : false,
-            RegExp              : false,
-            String              : false,
-            SyntaxError         : false,
-            TypeError           : false,
-            URIError            : false
-        },
+        standard = array_to_object([
+            'Array', 'Boolean', 'Date', 'decodeURI', 'decodeURIComponent',
+            'encodeURI', 'encodeURIComponent', 'Error', 'eval', 'EvalError',
+            'Function', 'isFinite', 'isNaN', 'JSON', 'Math', 'Number', 'Object',
+            'parseInt', 'parseFloat', 'RangeError', 'ReferenceError', 'RegExp',
+            'String', 'SyntaxError', 'TypeError', 'URIError'
+        ], false),
 
-        standard_property = {
-            E                   : true,
-            LN2                 : true,
-            LN10                : true,
-            LOG2E               : true,
-            LOG10E              : true,
-            MAX_VALUE           : true,
-            MIN_VALUE           : true,
-            NEGATIVE_INFINITY   : true,
-            PI                  : true,
-            POSITIVE_INFINITY   : true,
-            SQRT1_2             : true,
-            SQRT2               : true
+        standard_property_type = {
+            E                   : 'number',
+            LN2                 : 'number',
+            LN10                : 'number',
+            LOG2E               : 'number',
+            LOG10E              : 'number',
+            MAX_VALUE           : 'number',
+            MIN_VALUE           : 'number',
+            NEGATIVE_INFINITY   : 'number',
+            PI                  : 'number',
+            POSITIVE_INFINITY   : 'number',
+            SQRT1_2             : 'number',
+            SQRT2               : 'number',
+            apply               : 'function',
+            bind                : 'function function',
+            call                : 'function',
+            ceil                : 'function number',
+            charAt              : 'function string',
+            concat              : 'function',
+            constructor         : 'function object',
+            create              : 'function object',
+            defineProperty      : 'function object',
+            defineProperties    : 'function object',
+            every               : 'function boolean',
+            exec                : 'function array',
+            filter              : 'function array',
+            floor               : 'function number',
+            forEach             : 'function',
+            freeze              : 'function object',
+            getDate             : 'function number',
+            getDay              : 'function number',
+            getFullYear         : 'function number',
+            getHours            : 'function number',
+            getMilliseconds     : 'function number',
+            getMinutes          : 'function number',
+            getMonth            : 'function number',
+            getOwnPropertyDescriptor
+                                : 'function object',
+            getOwnPropertyNames : 'function array',
+            getPrototypeOf      : 'function object',
+            getSeconds          : 'function number',
+            getTime             : 'function number',
+            getTimezoneOffset   : 'function number',
+            getUTCDate          : 'function number',
+            getUTCDay           : 'function number',
+            getUTCFullYear      : 'function number',
+            getUTCHours         : 'function number',
+            getUTCMilliseconds  : 'function number',
+            getUTCMinutes       : 'function number',
+            getUTCMonth         : 'function number',
+            getUTCSeconds       : 'function number',
+            getYear             : 'function number',
+            hasOwnProperty      : 'function boolean',
+            indexOf             : 'function number',
+            isExtensible        : 'function boolean',
+            isFrozen            : 'function boolean',
+            isPrototypeOf       : 'function boolean',
+            isSealed            : 'function boolean',
+            join                : 'function string',
+            keys                : 'function array',
+            lastIndexOf         : 'function number',
+            lastIndex           : 'number',
+            length              : 'number',
+            map                 : 'function array',
+            now                 : 'function number',
+            parse               : 'function',
+            pop                 : 'function',
+            preventExtensions   : 'function object',
+            propertyIsEnumerable: 'function boolean',
+            prototype           : 'object',
+            push                : 'function number',
+            reduce              : 'function',
+            reduceRight         : 'function',
+            reverse             : 'function',
+            seal                : 'function object',
+            setDate             : 'function',
+            setDay              : 'function',
+            setFullYear         : 'function',
+            setHours            : 'function',
+            setMilliseconds     : 'function',
+            setMinutes          : 'function',
+            setMonth            : 'function',
+            setSeconds          : 'function',
+            setTime             : 'function',
+            setTimezoneOffset   : 'function',
+            setUTCDate          : 'function',
+            setUTCDay           : 'function',
+            setUTCFullYear      : 'function',
+            setUTCHours         : 'function',
+            setUTCMilliseconds  : 'function',
+            setUTCMinutes       : 'function',
+            setUTCMonth         : 'function',
+            setUTCSeconds       : 'function',
+            setYear             : 'function',
+            shift               : 'function',
+            slice               : 'function',
+            some                : 'function boolean',
+            sort                : 'function',
+            splice              : 'function',
+            stringify           : 'function string',
+            substr              : 'function string',
+            substring           : 'function string',
+            test                : 'function boolean',
+            toDateString        : 'function string',
+            toExponential       : 'function string',
+            toFixed             : 'function string',
+            toJSON              : 'function',
+            toISOString         : 'function string',
+            toLocaleDateString  : 'function string',
+            toLocaleLowerCase   : 'function string',
+            toLocaleUpperCase   : 'function string',
+            toLocaleString      : 'function string',
+            toLocaleTimeString  : 'function string',
+            toLowerCase         : 'function string',
+            toPrecision         : 'function string',
+            toTimeString        : 'function string',
+            toUpperCase         : 'function string',
+            toUTCString         : 'function string',
+            trim                : 'function string',
+            unshift             : 'function number',
+            valueOf             : 'function'
         },
 
         strict_mode,
         syntax = {},
         tab,
         token,
+//         type_state_change,
         urls,
         var_mode,
         warnings,
@@ -1129,102 +1084,39 @@ var JSLINT = (function () {
 // widget contains the global names which are provided to a Yahoo
 // (fna Konfabulator) widget.
 
-        widget = {
-            alert                   : true,
-            animator                : true,
-            appleScript             : true,
-            beep                    : true,
-            bytesToUIString         : true,
-            Canvas                  : true,
-            chooseColor             : true,
-            chooseFile              : true,
-            chooseFolder            : true,
-            closeWidget             : true,
-            COM                     : true,
-            convertPathToHFS        : true,
-            convertPathToPlatform   : true,
-            CustomAnimation         : true,
-            escape                  : true,
-            FadeAnimation           : true,
-            filesystem              : true,
-            Flash                   : true,
-            focusWidget             : true,
-            form                    : true,
-            FormField               : true,
-            Frame                   : true,
-            HotKey                  : true,
-            Image                   : true,
-            include                 : true,
-            isApplicationRunning    : true,
-            iTunes                  : true,
-            konfabulatorVersion     : true,
-            log                     : true,
-            md5                     : true,
-            MenuItem                : true,
-            MoveAnimation           : true,
-            openURL                 : true,
-            play                    : true,
-            Point                   : true,
-            popupMenu               : true,
-            preferenceGroups        : true,
-            preferences             : true,
-            print                   : true,
-            prompt                  : true,
-            random                  : true,
-            Rectangle               : true,
-            reloadWidget            : true,
-            ResizeAnimation         : true,
-            resolvePath             : true,
-            resumeUpdates           : true,
-            RotateAnimation         : true,
-            runCommand              : true,
-            runCommandInBg          : true,
-            saveAs                  : true,
-            savePreferences         : true,
-            screen                  : true,
-            ScrollBar               : true,
-            showWidgetPreferences   : true,
-            sleep                   : true,
-            speak                   : true,
-            Style                   : true,
-            suppressUpdates         : true,
-            system                  : true,
-            tellWidget              : true,
-            Text                    : true,
-            TextArea                : true,
-            Timer                   : true,
-            unescape                : true,
-            updateNow               : true,
-            URL                     : true,
-            Web                     : true,
-            widget                  : true,
-            Window                  : true,
-            XMLDOM                  : true,
-            XMLHttpRequest          : true,
-            yahooCheckLogin         : true,
-            yahooLogin              : true,
-            yahooLogout             : true
-        },
+        widget = array_to_object([
+            'alert', 'animator', 'appleScript', 'beep', 'bytesToUIString',
+            'Canvas', 'chooseColor', 'chooseFile', 'chooseFolder',
+            'closeWidget', 'COM', 'convertPathToHFS', 'convertPathToPlatform',
+            'CustomAnimation', 'escape', 'FadeAnimation', 'filesystem', 'Flash',
+            'focusWidget', 'form', 'FormField', 'Frame', 'HotKey', 'Image',
+            'include', 'isApplicationRunning', 'iTunes', 'konfabulatorVersion',
+            'log', 'md5', 'MenuItem', 'MoveAnimation', 'openURL', 'play',
+            'Point', 'popupMenu', 'preferenceGroups', 'preferences', 'print',
+            'prompt', 'random', 'Rectangle', 'reloadWidget', 'ResizeAnimation',
+            'resolvePath', 'resumeUpdates', 'RotateAnimation', 'runCommand',
+            'runCommandInBg', 'saveAs', 'savePreferences', 'screen',
+            'ScrollBar', 'showWidgetPreferences', 'sleep', 'speak', 'Style',
+            'suppressUpdates', 'system', 'tellWidget', 'Text', 'TextArea',
+            'Timer', 'unescape', 'updateNow', 'URL', 'Web', 'widget', 'Window',
+            'XMLDOM', 'XMLHttpRequest', 'yahooCheckLogin', 'yahooLogin',
+            'yahooLogout'
+        ], true),
 
-        windows = {
-            ActiveXObject: false,
-            CScript      : false,
-            Debug        : false,
-            Enumerator   : false,
-            System       : false,
-            VBArray      : false,
-            WScript      : false
-        },
+        windows = array_to_object([
+            'ActiveXObject', 'CScript', 'Debug', 'Enumerator', 'System',
+            'VBArray', 'WScript', 'WSH'
+        ], false),
 
 //  xmode is used to adapt to the exceptions in html parsing.
 //  It can have these states:
-//      false   .js script file
-//      html
-//      outer
-//      script
-//      style
-//      scriptstring
-//      styleproperty
+//      ''      .js script file
+//      'html'
+//      'outer'
+//      'script'
+//      'style'
+//      'scriptstring'
+//      'styleproperty'
 
         xmode,
         xquote,
@@ -1233,6 +1125,9 @@ var JSLINT = (function () {
 
 // unsafe comment or string
         ax = /@cc|<\/?|script|\]\s*\]|<\s*!|&lt/i,
+// carriage return, or carriage return linefeed
+        crx = /\r/g,
+        crlfx = /\r\n/g,
 // unsafe characters that are silently deleted by one or more browsers
         cx = /[\u0000-\u001f\u007f-\u009f\u00ad\u0600-\u0604\u070f\u17b4\u17b5\u200c-\u200f\u2028-\u202f\u2060-\u206f\ufeff\ufff0-\uffff]/,
 // query characters for ids
@@ -1252,12 +1147,12 @@ var JSLINT = (function () {
 // attributes characters
         qx = /[^a-zA-Z0-9+\-_\/ ]/,
 // style
-        sx = /^\s*([{:#%.=,>+\[\]@()"';]|\*=?|\$=|\|=|\^=|~=|[a-zA-Z_][a-zA-Z0-9_\-]*|[0-9]+|<\/|\/\*)/,
+        sx = /^\s*([{}:#%.=,>+\[\]@()"';]|[*$\^~]=|[a-zA-Z_][a-zA-Z0-9_\-]*|[0-9]+|<\/|\/\*)/,
         ssx = /^\s*([@#!"'};:\-%.=,+\[\]()*_]|[a-zA-Z][a-zA-Z0-9._\-]*|\/\*?|\d+(?:\.\d+)?|<\/)/,
 // token
-        tx = /^\s*([(){}\[.,:;'"~\?\]#@]|==?=?|\/(\*(jslint|properties|property|members?|globals?)?|=|\/)?|\*[\/=]?|\+(?:=|\++)?|-(?:=|-+)?|%=?|&[&=]?|\|[|=]?|>>?>?=?|<([\/=!]|\!(\[|--)?|<=?)?|\^=?|\!=?=?|[a-zA-Z_$][a-zA-Z0-9_$]*|[0-9]+([xX][0-9a-fA-F]+|\.[0-9]*)?([eE][+\-]?[0-9]+)?)/,
+        tx = /^\s*([(){}\[\]\?.,:;'"~#@`]|={1,3}|\/(\*(jslint|properties|property|members?|globals?)?|=|\/)?|\*[\/=]?|\+(?:=|\++)?|-(?:=|-+)?|[\^%]=?|&[&=]?|\|[|=]?|>{1,3}=?|<(?:[\/=!]|\!(\[|--)?|<=?)?|\!={0,2}|[a-zA-Z_$][a-zA-Z0-9_$]*|[0-9]+(?:[xX][0-9a-fA-F]+|\.[0-9]*)?(?:[eE][+\-]?[0-9]+)?)/,
 // url badness
-        ux = /&|\+|\u00AD|\.\.|\/\*|%[^;]|base64|url|expression|data|mailto/i,
+        ux = /&|\+|\u00AD|\.\.|\/\*|%[^;]|base64|url|expression|data|mailto|script/i,
 
         rx = {
             outer: hx,
@@ -1267,24 +1162,35 @@ var JSLINT = (function () {
         };
 
 
-    function return_this() {
-        return this;
-    }
-
     function F() {}     // Used by Object.create
 
 // Provide critical ES5 functions to ES3.
 
     if (typeof Array.prototype.filter !== 'function') {
         Array.prototype.filter = function (f) {
-            var i, length = this.length, result = [];
+            var i, length = this.length, result = [], value;
             for (i = 0; i < length; i += 1) {
                 try {
-                    result.push(f(this[i]));
+                    value = this[i];
+                    if (f(value)) {
+                        result.push(value);
+                    }
                 } catch (ignore) {
                 }
             }
             return result;
+        };
+    }
+
+    if (typeof Array.prototype.forEach !== 'function') {
+        Array.prototype.forEach = function (f) {
+            var i, length = this.length;
+            for (i = 0; i < length; i += 1) {
+                try {
+                    f(this[i]);
+                } catch (ignore) {
+                }
+            }
         };
     }
 
@@ -1294,7 +1200,7 @@ var JSLINT = (function () {
         };
     }
 
-    if (!Object.hasOwnProperty('create')) {
+    if (!Object.prototype.hasOwnProperty.call(Object, 'create')) {
         Object.create = function (o) {
             F.prototype = o;
             return new F();
@@ -1312,8 +1218,6 @@ var JSLINT = (function () {
             return array;
         };
     }
-
-// Substandard methods
 
     if (typeof String.prototype.entityify !== 'function') {
         String.prototype.entityify = function () {
@@ -1352,45 +1256,60 @@ var JSLINT = (function () {
 
 //  Escapify a troublesome character.
 
-        return escapes[a] ? escapes[a] :
+        return escapes[a] ||
             '\\u' + ('0000' + a.charCodeAt().toString(16)).slice(-4);
     }
 
 
-    function combine(a, b) {
-        var name;
-        for (name in b) {
-            if (Object.prototype.hasOwnProperty.call(b, name)) {
-                a[name] = b[name];
-            }
-        }
+    function add_to_predefined(group) {
+        Object.keys(group).forEach(function (name) {
+            predefined[name] = group[name];
+        });
     }
+
 
     function assume() {
         if (!option.safe) {
             if (option.rhino) {
-                combine(predefined, rhino);
+                add_to_predefined(rhino);
+                option.rhino = false;
             }
             if (option.devel) {
-                combine(predefined, devel);
+                add_to_predefined(devel);
+                option.devel = false;
             }
             if (option.browser) {
-                combine(predefined, browser);
+                add_to_predefined(browser);
+                option.browser = false;
             }
             if (option.windows) {
-                combine(predefined, windows);
+                add_to_predefined(windows);
+                option.windows = false;
             }
             if (option.node) {
-                combine(predefined, node);
+                add_to_predefined(node);
+                option.node = false;
+                node_js = true;
             }
             if (option.widget) {
-                combine(predefined, widget);
+                add_to_predefined(widget);
+                option.widget = false;
             }
+        }
+        if (option.type) {
+            option.confusion = true;
         }
     }
 
 
 // Produce an error warning.
+
+    function artifact(tok) {
+        if (!tok) {
+            tok = next_token;
+        }
+        return tok.number || tok.string;
+    }
 
     function quit(message, line, character) {
         throw {
@@ -1415,7 +1334,9 @@ var JSLINT = (function () {
             evidence: lines[line - 1] || '',
             line: line,
             character: character,
-            a: a || offender.value,
+            a: a || (offender.id === '(number)'
+                ? String(offender.number)
+                : offender.string),
             b: b,
             c: c,
             d: d
@@ -1452,8 +1373,8 @@ var JSLINT = (function () {
     }
 
     function expected_at(at) {
-        if (option.white && next_token.from !== at) {
-            warn('expected_a_at_b_c', next_token, next_token.value, at,
+        if (!option.white && next_token.from !== at) {
+            warn('expected_a_at_b_c', next_token, '', at,
                 next_token.from);
         }
     }
@@ -1470,33 +1391,10 @@ var JSLINT = (function () {
 
 // lexical analysis and token construction
 
-    var lex = (function lex() {
-        var character, from, line, source_row;
+    lex = (function lex() {
+        var character, c, from, length, line, pos, source_row;
 
 // Private lex methods
-
-        function collect_comment(comment, quote, line, at) {
-            var comment_object = {
-                comment: comment,
-                quote: quote,
-                at: at,
-                line: line
-            };
-            if (comments_off || src || (xmode && xmode !== 'script' &&
-                    xmode !== 'style' && xmode !== 'styleproperty')) {
-                warn_at('unexpected_comment', line, character);
-            } else if (xmode === 'script' && /<\//i.test(source_row)) {
-                warn_at('unexpected_a', line, character, '<\/');
-            } else if (option.safe && ax.test(comment)) {
-                warn_at('dangerous_comment', line, at);
-            }
-            if (older_token.comments) {
-                older_token.comments.push(comment_object);
-            } else {
-                older_token.comments = [comment_object];
-            }
-            JSLINT.comments.push(comment_object);
-        }
 
         function next_line() {
             var at;
@@ -1523,7 +1421,7 @@ var JSLINT = (function () {
 
 // Produce a token object.  The token inherits from a syntax symbol.
 
-        function it(type, value, quote) {
+        function it(type, value) {
             var id, the_token;
             if (type === '(string)' || type === '(range)') {
                 if (jx.test(value)) {
@@ -1531,40 +1429,456 @@ var JSLINT = (function () {
                 }
             }
             the_token = Object.create(syntax[(
-                type === '(punctuator)' ||
-                    (type === '(identifier)' &&
-                    Object.prototype.hasOwnProperty.call(syntax, value)) ?
-                value :
-                type
+                type === '(punctuator)' || (type === '(identifier)' &&
+                        Object.prototype.hasOwnProperty.call(syntax, value))
+                    ? value
+                    : type
             )] || syntax['(error)']);
             if (type === '(identifier)') {
                 the_token.identifier = true;
                 if (value === '__iterator__' || value === '__proto__') {
                     stop_at('reserved_a', line, from, value);
-                } else if (option.nomen &&
+                } else if (!option.nomen &&
                         (value.charAt(0) === '_' ||
                         value.charAt(value.length - 1) === '_')) {
                     warn_at('dangling_a', line, from, value);
                 }
             }
-            if (value !== undefined) {
-                the_token.value = value;
-            }
-            if (quote) {
-                the_token.quote = quote;
+            if (type === '(number)') {
+                the_token.number = +value;
+            } else if (value !== undefined) {
+                the_token.string = String(value);
             }
             the_token.line = line;
             the_token.from = from;
             the_token.thru = character;
-            the_token.prev = older_token;
             id = the_token.id;
             prereg = id && (
                 ('(,=:[!&|?{};'.indexOf(id.charAt(id.length - 1)) >= 0) ||
-                id === 'return'
+                id === 'return' || id === 'case'
             );
-            older_token.next = the_token;
-            older_token = the_token;
             return the_token;
+        }
+
+        function match(x) {
+            var exec = x.exec(source_row), first;
+            if (exec) {
+                length = exec[0].length;
+                first = exec[1];
+                c = first.charAt(0);
+                source_row = source_row.slice(length);
+                from = character + length - first.length;
+                character += length;
+                return first;
+            }
+        }
+
+        function string(x) {
+            var c, pos = 0, r = '', result;
+
+            function hex(n) {
+                var i = parseInt(source_row.substr(pos + 1, n), 16);
+                pos += n;
+                if (i >= 32 && i <= 126 &&
+                        i !== 34 && i !== 92 && i !== 39) {
+                    warn_at('unexpected_a', line, character, '\\');
+                }
+                character += n;
+                c = String.fromCharCode(i);
+            }
+
+            if (json_mode && x !== '"') {
+                warn_at('expected_a', line, character, '"');
+            }
+
+            if (xquote === x || (xmode === 'scriptstring' && !xquote)) {
+                return it('(punctuator)', x);
+            }
+
+            for (;;) {
+                while (pos >= source_row.length) {
+                    pos = 0;
+                    if (xmode !== 'html' || !next_line()) {
+                        stop_at('unclosed', line, from);
+                    }
+                }
+                c = source_row.charAt(pos);
+                if (c === x) {
+                    character += 1;
+                    source_row = source_row.slice(pos + 1);
+                    result = it('(string)', r);
+                    result.quote = x;
+                    return result;
+                }
+                if (c < ' ') {
+                    if (c === '\n' || c === '\r') {
+                        break;
+                    }
+                    warn_at('control_a', line, character + pos,
+                        source_row.slice(0, pos));
+                } else if (c === xquote) {
+                    warn_at('bad_html', line, character + pos);
+                } else if (c === '<') {
+                    if (option.safe && xmode === 'html') {
+                        warn_at('adsafe_a', line, character + pos, c);
+                    } else if (source_row.charAt(pos + 1) === '/' && (xmode || option.safe)) {
+                        warn_at('expected_a_b', line, character,
+                            '<\\/', '</');
+                    } else if (source_row.charAt(pos + 1) === '!' && (xmode || option.safe)) {
+                        warn_at('unexpected_a', line, character, '<!');
+                    }
+                } else if (c === '\\') {
+                    if (xmode === 'html') {
+                        if (option.safe) {
+                            warn_at('adsafe_a', line, character + pos, c);
+                        }
+                    } else if (xmode === 'styleproperty') {
+                        pos += 1;
+                        character += 1;
+                        c = source_row.charAt(pos);
+                        if (c !== x) {
+                            warn_at('unexpected_a', line, character, '\\');
+                        }
+                    } else {
+                        pos += 1;
+                        character += 1;
+                        c = source_row.charAt(pos);
+                        switch (c) {
+                        case '':
+                            if (!option.es5) {
+                                warn_at('es5', line, character);
+                            }
+                            next_line();
+                            pos = -1;
+                            break;
+                        case xquote:
+                            warn_at('bad_html', line, character + pos);
+                            break;
+                        case '\'':
+                            if (json_mode) {
+                                warn_at('unexpected_a', line, character, '\\\'');
+                            }
+                            break;
+                        case 'u':
+                            hex(4);
+                            break;
+                        case 'v':
+                            if (json_mode) {
+                                warn_at('unexpected_a', line, character, '\\v');
+                            }
+                            c = '\v';
+                            break;
+                        case 'x':
+                            if (json_mode) {
+                                warn_at('unexpected_a', line, character, '\\x');
+                            }
+                            hex(2);
+                            break;
+                        default:
+                            c = descapes[c];
+                            if (typeof c !== 'string') {
+                                warn_at('unexpected_a', line, character, '\\');
+                            }
+                        }
+                    }
+                }
+                r += c;
+                character += 1;
+                pos += 1;
+            }
+        }
+
+        function number(snippet) {
+            var digit;
+            if (xmode !== 'style' && xmode !== 'styleproperty' &&
+                    source_row.charAt(0).isAlpha()) {
+                warn_at('expected_space_a_b',
+                    line, character, c, source_row.charAt(0));
+            }
+            if (c === '0') {
+                digit = snippet.charAt(1);
+                if (digit.isDigit()) {
+                    if (token.id !== '.' && xmode !== 'styleproperty') {
+                        warn_at('unexpected_a', line, character, snippet);
+                    }
+                } else if (json_mode && (digit === 'x' || digit === 'X')) {
+                    warn_at('unexpected_a', line, character, '0x');
+                }
+            }
+            if (snippet.slice(snippet.length - 1) === '.') {
+                warn_at('trailing_decimal_a', line, character, snippet);
+            }
+            if (xmode !== 'style') {
+                digit = +snippet;
+                if (!isFinite(digit)) {
+                    warn_at('bad_number', line, character, snippet);
+                }
+                snippet = digit;
+            }
+            return it('(number)', snippet);
+        }
+
+        function comment(snippet) {
+            if (comments_off || src || (xmode && xmode !== 'script' &&
+                    xmode !== 'style' && xmode !== 'styleproperty')) {
+                warn_at('unexpected_comment', line, character);
+            } else if (xmode === 'script' && /<\//i.test(source_row)) {
+                warn_at('unexpected_a', line, character, '<\/');
+            } else if (option.safe && ax.test(snippet)) {
+                warn_at('dangerous_comment', line, character);
+            }
+        }
+
+        function regexp() {
+            var b,
+                bit,
+                captures = 0,
+                depth = 0,
+                flag = '',
+                high,
+                letter,
+                length = 0,
+                low,
+                potential,
+                quote,
+                result;
+            for (;;) {
+                b = true;
+                c = source_row.charAt(length);
+                length += 1;
+                switch (c) {
+                case '':
+                    stop_at('unclosed_regexp', line, from);
+                    return;
+                case '/':
+                    if (depth > 0) {
+                        warn_at('unescaped_a', line, from + length, '/');
+                    }
+                    c = source_row.slice(0, length - 1);
+                    potential = Object.create(regexp_flag);
+                    for (;;) {
+                        letter = source_row.charAt(length);
+                        if (potential[letter] !== true) {
+                            break;
+                        }
+                        potential[letter] = false;
+                        length += 1;
+                        flag += letter;
+                    }
+                    if (source_row.charAt(length).isAlpha()) {
+                        stop_at('unexpected_a', line, from, source_row.charAt(length));
+                    }
+                    character += length;
+                    source_row = source_row.slice(length);
+                    quote = source_row.charAt(0);
+                    if (quote === '/' || quote === '*') {
+                        stop_at('confusing_regexp', line, from);
+                    }
+                    result = it('(regexp)', c);
+                    result.flag = flag;
+                    return result;
+                case '\\':
+                    c = source_row.charAt(length);
+                    if (c < ' ') {
+                        warn_at('control_a', line, from + length, String(c));
+                    } else if (c === '<') {
+                        warn_at(bundle.unexpected_a, line, from + length, '\\');
+                    }
+                    length += 1;
+                    break;
+                case '(':
+                    depth += 1;
+                    b = false;
+                    if (source_row.charAt(length) === '?') {
+                        length += 1;
+                        switch (source_row.charAt(length)) {
+                        case ':':
+                        case '=':
+                        case '!':
+                            length += 1;
+                            break;
+                        default:
+                            warn_at(bundle.expected_a_b, line, from + length,
+                                ':', source_row.charAt(length));
+                        }
+                    } else {
+                        captures += 1;
+                    }
+                    break;
+                case '|':
+                    b = false;
+                    break;
+                case ')':
+                    if (depth === 0) {
+                        warn_at('unescaped_a', line, from + length, ')');
+                    } else {
+                        depth -= 1;
+                    }
+                    break;
+                case ' ':
+                    pos = 1;
+                    while (source_row.charAt(length) === ' ') {
+                        length += 1;
+                        pos += 1;
+                    }
+                    if (pos > 1) {
+                        warn_at('use_braces', line, from + length, pos);
+                    }
+                    break;
+                case '[':
+                    c = source_row.charAt(length);
+                    if (c === '^') {
+                        length += 1;
+                        if (!option.regexp) {
+                            warn_at('insecure_a', line, from + length, c);
+                        } else if (source_row.charAt(length) === ']') {
+                            stop_at('unescaped_a', line, from + length, '^');
+                        }
+                    }
+                    bit = false;
+                    if (c === ']') {
+                        warn_at('empty_class', line, from + length - 1);
+                        bit = true;
+                    }
+klass:              do {
+                        c = source_row.charAt(length);
+                        length += 1;
+                        switch (c) {
+                        case '[':
+                        case '^':
+                            warn_at('unescaped_a', line, from + length, c);
+                            bit = true;
+                            break;
+                        case '-':
+                            if (bit) {
+                                bit = false;
+                            } else {
+                                warn_at('unescaped_a', line, from + length, '-');
+                                bit = true;
+                            }
+                            break;
+                        case ']':
+                            if (!bit) {
+                                warn_at('unescaped_a', line, from + length - 1, '-');
+                            }
+                            break klass;
+                        case '\\':
+                            c = source_row.charAt(length);
+                            if (c < ' ') {
+                                warn_at(bundle.control_a, line, from + length, String(c));
+                            } else if (c === '<') {
+                                warn_at(bundle.unexpected_a, line, from + length, '\\');
+                            }
+                            length += 1;
+                            bit = true;
+                            break;
+                        case '/':
+                            warn_at('unescaped_a', line, from + length - 1, '/');
+                            bit = true;
+                            break;
+                        case '<':
+                            if (xmode === 'script') {
+                                c = source_row.charAt(length);
+                                if (c === '!' || c === '/') {
+                                    warn_at(bundle.html_confusion_a, line,
+                                        from + length, c);
+                                }
+                            }
+                            bit = true;
+                            break;
+                        default:
+                            bit = true;
+                        }
+                    } while (c);
+                    break;
+                case '.':
+                    if (!option.regexp) {
+                        warn_at('insecure_a', line, from + length, c);
+                    }
+                    break;
+                case ']':
+                case '?':
+                case '{':
+                case '}':
+                case '+':
+                case '*':
+                    warn_at('unescaped_a', line, from + length, c);
+                    break;
+                case '<':
+                    if (xmode === 'script') {
+                        c = source_row.charAt(length);
+                        if (c === '!' || c === '/') {
+                            warn_at(bundle.html_confusion_a, line, from + length, c);
+                        }
+                    }
+                    break;
+                }
+                if (b) {
+                    switch (source_row.charAt(length)) {
+                    case '?':
+                    case '+':
+                    case '*':
+                        length += 1;
+                        if (source_row.charAt(length) === '?') {
+                            length += 1;
+                        }
+                        break;
+                    case '{':
+                        length += 1;
+                        c = source_row.charAt(length);
+                        if (c < '0' || c > '9') {
+                            warn_at(bundle.expected_number_a, line,
+                                from + length, c);
+                        }
+                        length += 1;
+                        low = +c;
+                        for (;;) {
+                            c = source_row.charAt(length);
+                            if (c < '0' || c > '9') {
+                                break;
+                            }
+                            length += 1;
+                            low = +c + (low * 10);
+                        }
+                        high = low;
+                        if (c === ',') {
+                            length += 1;
+                            high = Infinity;
+                            c = source_row.charAt(length);
+                            if (c >= '0' && c <= '9') {
+                                length += 1;
+                                high = +c;
+                                for (;;) {
+                                    c = source_row.charAt(length);
+                                    if (c < '0' || c > '9') {
+                                        break;
+                                    }
+                                    length += 1;
+                                    high = +c + (high * 10);
+                                }
+                            }
+                        }
+                        if (source_row.charAt(length) !== '}') {
+                            warn_at(bundle.expected_a_b, line, from + length,
+                                '}', c);
+                        } else {
+                            length += 1;
+                        }
+                        if (source_row.charAt(length) === '?') {
+                            length += 1;
+                        }
+                        if (low > high) {
+                            warn_at(bundle.not_greater, line, from + length,
+                                low, high);
+                        }
+                        break;
+                    }
+                }
+            }
+            c = source_row.slice(0, length - 1);
+            character += length;
+            source_row = source_row.slice(length);
+            return it('(regexp)', c);
         }
 
 // Public lex methods
@@ -1573,8 +1887,8 @@ var JSLINT = (function () {
             init: function (source) {
                 if (typeof source === 'string') {
                     lines = source
-                        .replace(/\r\n/g, '\n')
-                        .replace(/\r/g, '\n')
+                        .replace(crlfx, '\n')
+                        .replace(crx, '\n')
                         .split('\n');
                 } else {
                     lines = source;
@@ -1615,150 +1929,7 @@ var JSLINT = (function () {
 // token -- this is called by advance to get the next token.
 
             token: function () {
-                var b, c, captures, digit, depth, flag, high, i, j, length, low, quote, symbol;
-
-                function match(x) {
-                    var exec = x.exec(source_row), first;
-                    if (exec) {
-                        length = exec[0].length;
-                        first = exec[1];
-                        c = first.charAt(0);
-                        source_row = source_row.substr(length);
-                        from = character + length - first.length;
-                        character += length;
-                        return first;
-                    }
-                }
-
-                function string(x) {
-                    var c, j, r = '';
-
-                    function hex(n) {
-                        var i = parseInt(source_row.substr(j + 1, n), 16);
-                        j += n;
-                        if (i >= 32 && i <= 126 &&
-                                i !== 34 && i !== 92 && i !== 39) {
-                            warn_at('unexpected_a', line, character, '\\');
-                        }
-                        character += n;
-                        c = String.fromCharCode(i);
-                    }
-
-                    if (json_mode && x !== '"') {
-                        warn_at('expected_a', line, character, '"');
-                    }
-
-                    if (xquote === x || (xmode === 'scriptstring' && !xquote)) {
-                        return it('(punctuator)', x);
-                    }
-
-                    j = 0;
-                    for (;;) {
-                        while (j >= source_row.length) {
-                            j = 0;
-                            if (xmode !== 'html' || !next_line()) {
-                                stop_at('unclosed', line, from);
-                            }
-                        }
-                        c = source_row.charAt(j);
-                        if (c === x) {
-                            character += 1;
-                            source_row = source_row.substr(j + 1);
-                            return it('(string)', r, x);
-                        }
-                        if (c < ' ') {
-                            if (c === '\n' || c === '\r') {
-                                break;
-                            }
-                            warn_at('control_a',
-                                line, character + j, source_row.slice(0, j));
-                        } else if (c === xquote) {
-                            warn_at('bad_html', line, character + j);
-                        } else if (c === '<') {
-                            if (option.safe && xmode === 'html') {
-                                warn_at('adsafe_a', line, character + j, c);
-                            } else if (source_row.charAt(j + 1) === '/' && (xmode || option.safe)) {
-                                warn_at('expected_a_b', line, character,
-                                    '<\\/', '</');
-                            } else if (source_row.charAt(j + 1) === '!' && (xmode || option.safe)) {
-                                warn_at('unexpected_a', line, character, '<!');
-                            }
-                        } else if (c === '\\') {
-                            if (xmode === 'html') {
-                                if (option.safe) {
-                                    warn_at('adsafe_a', line, character + j, c);
-                                }
-                            } else if (xmode === 'styleproperty') {
-                                j += 1;
-                                character += 1;
-                                c = source_row.charAt(j);
-                                if (c !== x) {
-                                    warn_at('unexpected_a', line, character, '\\');
-                                }
-                            } else {
-                                j += 1;
-                                character += 1;
-                                c = source_row.charAt(j);
-                                switch (c) {
-                                case '':
-                                    if (!option.es5) {
-                                        warn_at('es5', line, character);
-                                    }
-                                    next_line();
-                                    j = -1;
-                                    break;
-                                case xquote:
-                                    warn_at('bad_html', line, character + j);
-                                    break;
-                                case '\\':
-                                case '"':
-                                case '/':
-                                    break;
-                                case '\'':
-                                    if (json_mode) {
-                                        warn_at('unexpected_a', line, character, '\\\'');
-                                    }
-                                    break;
-                                case 'b':
-                                    c = '\b';
-                                    break;
-                                case 'f':
-                                    c = '\f';
-                                    break;
-                                case 'n':
-                                    c = '\n';
-                                    break;
-                                case 'r':
-                                    c = '\r';
-                                    break;
-                                case 't':
-                                    c = '\t';
-                                    break;
-                                case 'u':
-                                    hex(4);
-                                    break;
-                                case 'v':
-                                    if (json_mode) {
-                                        warn_at('unexpected_a', line, character, '\\v');
-                                    }
-                                    c = '\v';
-                                    break;
-                                case 'x':
-                                    if (json_mode) {
-                                        warn_at('unexpected_a', line, character, '\\x');
-                                    }
-                                    hex(2);
-                                    break;
-                                default:
-                                    warn_at('unexpected_a', line, character, '\\');
-                                }
-                            }
-                        }
-                        r += c;
-                        character += 1;
-                        j += 1;
-                    }
-                }
+                var c, i, snippet;
 
                 for (;;) {
                     while (!source_row) {
@@ -1780,98 +1951,69 @@ var JSLINT = (function () {
                             }
                         }
                     }
-                    symbol = match(rx[xmode] || tx);
-                    if (!symbol) {
-                        symbol = '';
-                        c = '';
-                        while (source_row && source_row < '!') {
-                            source_row = source_row.substr(1);
-                        }
+                    snippet = match(rx[xmode] || tx);
+                    if (!snippet) {
                         if (source_row) {
-                            if (xmode === 'html') {
-                                return it('(error)', source_row.charAt(0));
+                            if (source_row.charAt(0) === ' ') {
+                                if (!option.white) {
+                                    warn_at('unexpected_a', line, character,
+                                        '(space)');
+                                }
+                                character += 1;
+                                source_row = '';
                             } else {
-                                stop_at('unexpected_a',
-                                    line, character, source_row.substr(0, 1));
+                                stop_at('unexpected_a', line, character,
+                                    source_row.charAt(0));
                             }
                         }
                     } else {
 
 //      identifier
 
+                        c = snippet.charAt(0);
                         if (c.isAlpha() || c === '_' || c === '$') {
-                            return it('(identifier)', symbol);
+                            return it('(identifier)', snippet);
                         }
 
 //      number
 
                         if (c.isDigit()) {
-                            if (xmode !== 'style' &&
-                                    xmode !== 'styleproperty' &&
-                                    source_row.substr(0, 1).isAlpha()) {
-                                warn_at('expected_space_a_b',
-                                    line, character, c, source_row.charAt(0));
-                            }
-                            if (c === '0') {
-                                digit = symbol.substr(1, 1);
-                                if (digit.isDigit()) {
-                                    if (token.id !== '.' && xmode !== 'styleproperty') {
-                                        warn_at('unexpected_a',
-                                            line, character, symbol);
-                                    }
-                                } else if (json_mode && (digit === 'x' || digit === 'X')) {
-                                    warn_at('unexpected_a', line, character, '0x');
-                                }
-                            }
-                            if (symbol.substr(symbol.length - 1) === '.') {
-                                warn_at('trailing_decimal_a', line,
-                                    character, symbol);
-                            }
-                            if (xmode !== 'style') {
-                                digit = +symbol;
-                                if (!isFinite(digit)) {
-                                    warn_at('bad_number', line, character, symbol);
-                                }
-                                symbol = digit;
-                            }
-                            return it('(number)', symbol);
+                            return number(snippet);
                         }
-                        switch (symbol) {
+                        switch (snippet) {
 
 //      string
 
                         case '"':
                         case "'":
-                            return string(symbol);
+                            return string(snippet);
 
 //      // comment
 
                         case '//':
-                            collect_comment(source_row, '//', line, character);
+                            comment(source_row);
                             source_row = '';
                             break;
 
 //      /* comment
 
                         case '/*':
-                            quote = '/*';
                             for (;;) {
                                 i = source_row.search(lx);
                                 if (i >= 0) {
                                     break;
                                 }
-                                collect_comment(source_row, quote, line, character);
-                                quote = '';
+                                comment(source_row);
                                 if (!next_line()) {
                                     stop_at('unclosed_comment', line, character);
                                 }
                             }
-                            collect_comment(source_row.slice(0, i), quote, character, line);
+                            comment(source_row.slice(0, i));
                             character += i + 2;
-                            if (source_row.substr(i, 1) === '/') {
+                            if (source_row.charAt(i) === '/') {
                                 stop_at('nested_comment', line, character);
                             }
-                            source_row = source_row.substr(i + 2);
+                            source_row = source_row.slice(i + 2);
                             break;
 
                         case '':
@@ -1885,306 +2027,15 @@ var JSLINT = (function () {
                                     from
                                 );
                             }
-                            if (prereg) {
-                                depth = 0;
-                                captures = 0;
-                                length = 0;
-                                for (;;) {
-                                    b = true;
-                                    c = source_row.charAt(length);
-                                    length += 1;
-                                    switch (c) {
-                                    case '':
-                                        stop_at('unclosed_regexp', line, from);
-                                        return;
-                                    case '/':
-                                        if (depth > 0) {
-                                            warn_at('unescaped_a',
-                                                line, from + length, '/');
-                                        }
-                                        c = source_row.substr(0, length - 1);
-                                        flag = Object.create(regexp_flag);
-                                        while (flag[source_row.charAt(length)] === true) {
-                                            flag[source_row.charAt(length)] = false;
-                                            length += 1;
-                                        }
-                                        if (source_row.charAt(length).isAlpha()) {
-                                            stop_at('unexpected_a',
-                                                line, from, source_row.charAt(length));
-                                        }
-                                        character += length;
-                                        source_row = source_row.substr(length);
-                                        quote = source_row.charAt(0);
-                                        if (quote === '/' || quote === '*') {
-                                            stop_at('confusing_regexp',
-                                                line, from);
-                                        }
-                                        return it('(regexp)', c);
-                                    case '\\':
-                                        c = source_row.charAt(length);
-                                        if (c < ' ') {
-                                            warn_at('control_a',
-                                                line, from + length, String(c));
-                                        } else if (c === '<') {
-                                            warn_at(
-                                                bundle.unexpected_a,
-                                                line,
-                                                from + length,
-                                                '\\'
-                                            );
-                                        }
-                                        length += 1;
-                                        break;
-                                    case '(':
-                                        depth += 1;
-                                        b = false;
-                                        if (source_row.charAt(length) === '?') {
-                                            length += 1;
-                                            switch (source_row.charAt(length)) {
-                                            case ':':
-                                            case '=':
-                                            case '!':
-                                                length += 1;
-                                                break;
-                                            default:
-                                                warn_at(
-                                                    bundle.expected_a_b,
-                                                    line,
-                                                    from + length,
-                                                    ':',
-                                                    source_row.charAt(length)
-                                                );
-                                            }
-                                        } else {
-                                            captures += 1;
-                                        }
-                                        break;
-                                    case '|':
-                                        b = false;
-                                        break;
-                                    case ')':
-                                        if (depth === 0) {
-                                            warn_at('unescaped_a',
-                                                line, from + length, ')');
-                                        } else {
-                                            depth -= 1;
-                                        }
-                                        break;
-                                    case ' ':
-                                        j = 1;
-                                        while (source_row.charAt(length) === ' ') {
-                                            length += 1;
-                                            j += 1;
-                                        }
-                                        if (j > 1) {
-                                            warn_at('use_braces',
-                                                line, from + length, j);
-                                        }
-                                        break;
-                                    case '[':
-                                        c = source_row.charAt(length);
-                                        if (c === '^') {
-                                            length += 1;
-                                            if (option.regexp) {
-                                                warn_at('insecure_a',
-                                                    line, from + length, c);
-                                            } else if (source_row.charAt(length) === ']') {
-                                                stop_at('unescaped_a',
-                                                    line, from + length, '^');
-                                            }
-                                        }
-                                        quote = false;
-                                        if (c === ']') {
-                                            warn_at('empty_class', line,
-                                                from + length - 1);
-                                            quote = true;
-                                        }
-klass:                                  do {
-                                            c = source_row.charAt(length);
-                                            length += 1;
-                                            switch (c) {
-                                            case '[':
-                                            case '^':
-                                                warn_at('unescaped_a',
-                                                    line, from + length, c);
-                                                quote = true;
-                                                break;
-                                            case '-':
-                                                if (quote) {
-                                                    quote = false;
-                                                } else {
-                                                    warn_at('unescaped_a',
-                                                        line, from + length, '-');
-                                                    quote = true;
-                                                }
-                                                break;
-                                            case ']':
-                                                if (!quote) {
-                                                    warn_at('unescaped_a',
-                                                        line, from + length - 1, '-');
-                                                }
-                                                break klass;
-                                            case '\\':
-                                                c = source_row.charAt(length);
-                                                if (c < ' ') {
-                                                    warn_at(
-                                                        bundle.control_a,
-                                                        line,
-                                                        from + length,
-                                                        String(c)
-                                                    );
-                                                } else if (c === '<') {
-                                                    warn_at(
-                                                        bundle.unexpected_a,
-                                                        line,
-                                                        from + length,
-                                                        '\\'
-                                                    );
-                                                }
-                                                length += 1;
-                                                quote = true;
-                                                break;
-                                            case '/':
-                                                warn_at('unescaped_a',
-                                                    line, from + length - 1, '/');
-                                                quote = true;
-                                                break;
-                                            case '<':
-                                                if (xmode === 'script') {
-                                                    c = source_row.charAt(length);
-                                                    if (c === '!' || c === '/') {
-                                                        warn_at(
-                                                            bundle.html_confusion_a,
-                                                            line,
-                                                            from + length,
-                                                            c
-                                                        );
-                                                    }
-                                                }
-                                                quote = true;
-                                                break;
-                                            default:
-                                                quote = true;
-                                            }
-                                        } while (c);
-                                        break;
-                                    case '.':
-                                        if (option.regexp) {
-                                            warn_at('insecure_a', line,
-                                                from + length, c);
-                                        }
-                                        break;
-                                    case ']':
-                                    case '?':
-                                    case '{':
-                                    case '}':
-                                    case '+':
-                                    case '*':
-                                        warn_at('unescaped_a', line,
-                                            from + length, c);
-                                        break;
-                                    case '<':
-                                        if (xmode === 'script') {
-                                            c = source_row.charAt(length);
-                                            if (c === '!' || c === '/') {
-                                                warn_at(
-                                                    bundle.html_confusion_a,
-                                                    line,
-                                                    from + length,
-                                                    c
-                                                );
-                                            }
-                                        }
-                                        break;
-                                    }
-                                    if (b) {
-                                        switch (source_row.charAt(length)) {
-                                        case '?':
-                                        case '+':
-                                        case '*':
-                                            length += 1;
-                                            if (source_row.charAt(length) === '?') {
-                                                length += 1;
-                                            }
-                                            break;
-                                        case '{':
-                                            length += 1;
-                                            c = source_row.charAt(length);
-                                            if (c < '0' || c > '9') {
-                                                warn_at(
-                                                    bundle.expected_number_a,
-                                                    line,
-                                                    from + length,
-                                                    c
-                                                );
-                                            }
-                                            length += 1;
-                                            low = +c;
-                                            for (;;) {
-                                                c = source_row.charAt(length);
-                                                if (c < '0' || c > '9') {
-                                                    break;
-                                                }
-                                                length += 1;
-                                                low = +c + (low * 10);
-                                            }
-                                            high = low;
-                                            if (c === ',') {
-                                                length += 1;
-                                                high = Infinity;
-                                                c = source_row.charAt(length);
-                                                if (c >= '0' && c <= '9') {
-                                                    length += 1;
-                                                    high = +c;
-                                                    for (;;) {
-                                                        c = source_row.charAt(length);
-                                                        if (c < '0' || c > '9') {
-                                                            break;
-                                                        }
-                                                        length += 1;
-                                                        high = +c + (high * 10);
-                                                    }
-                                                }
-                                            }
-                                            if (source_row.charAt(length) !== '}') {
-                                                warn_at(
-                                                    bundle.expected_a_b,
-                                                    line,
-                                                    from + length,
-                                                    '}',
-                                                    c
-                                                );
-                                            } else {
-                                                length += 1;
-                                            }
-                                            if (source_row.charAt(length) === '?') {
-                                                length += 1;
-                                            }
-                                            if (low > high) {
-                                                warn_at(
-                                                    bundle.not_greater,
-                                                    line,
-                                                    from + length,
-                                                    low,
-                                                    high
-                                                );
-                                            }
-                                            break;
-                                        }
-                                    }
-                                }
-                                c = source_row.substr(0, length - 1);
-                                character += length;
-                                source_row = source_row.substr(length);
-                                return it('(regexp)', c);
-                            }
-                            return it('(punctuator)', symbol);
+                            return prereg
+                                ? regexp()
+                                : it('(punctuator)', snippet);
 
 //      punctuator
 
                         case '<!--':
                             length = line;
-                            c = character;
+//                            c = character;
                             for (;;) {
                                 i = source_row.indexOf('--');
                                 if (i >= 0) {
@@ -2221,25 +2072,25 @@ klass:                                  do {
                                         break;
                                     }
                                     character += 1;
-                                    source_row = source_row.substr(1);
-                                    symbol += c;
+                                    source_row = source_row.slice(1);
+                                    snippet += c;
                                 }
-                                if (symbol.length !== 4 && symbol.length !== 7) {
+                                if (snippet.length !== 4 && snippet.length !== 7) {
                                     warn_at('bad_color_a', line,
-                                        from + length, symbol);
+                                        from + length, snippet);
                                 }
-                                return it('(color)', symbol);
+                                return it('(color)', snippet);
                             }
-                            return it('(punctuator)', symbol);
+                            return it('(punctuator)', snippet);
 
                         default:
                             if (xmode === 'outer' && c === '&') {
                                 character += 1;
-                                source_row = source_row.substr(1);
+                                source_row = source_row.slice(1);
                                 for (;;) {
                                     c = source_row.charAt(0);
                                     character += 1;
-                                    source_row = source_row.substr(1);
+                                    source_row = source_row.slice(1);
                                     if (c === ';') {
                                         break;
                                     }
@@ -2252,7 +2103,7 @@ klass:                                  do {
                                 }
                                 break;
                             }
-                            return it('(punctuator)', symbol);
+                            return it('(punctuator)', snippet);
                         }
                     }
                 }
@@ -2261,36 +2112,55 @@ klass:                                  do {
     }());
 
 
-    function add_label(symbol, type) {
+    function add_label(token, kind, name) {
 
-        if (option.safe && funct['(global)'] &&
-                typeof predefined[symbol] !== 'boolean') {
-            warn('adsafe_a', token, symbol);
-        } else if (symbol === 'hasOwnProperty') {
-            warn('bad_name_a', token, symbol);
-        }
+// Define the symbol in the current function in the current scope.
 
-// Define symbol in the current function in the current scope.
+        name = name || token.string;
 
-        if (Object.prototype.hasOwnProperty.call(funct, symbol) && !funct['(global)']) {
-            warn(funct[symbol] === true ?
-                bundle.used_before_a :
-                bundle.already_defined,
-                next_token, symbol);
-        }
-        funct[symbol] = type;
-        if (funct['(global)']) {
-            if (global[symbol] === false) {
-                warn('read_only');
+// Global variables cannot be created in the safe subset. If a global variable
+// already exists, do nothing. If it is predefined, define it.
+
+        if (funct === global_funct) {
+            if (option.safe) {
+                warn('adsafe_a', token, name);
             }
-            global[symbol] = true;
-            if (Object.prototype.hasOwnProperty.call(implied, symbol)) {
-                warn('used_before_a', next_token, symbol);
-                delete implied[symbol];
+            if (typeof global_funct[name] !== 'string') {
+                token.writeable = typeof predefined[name] === 'boolean'
+                    ? predefined[name]
+                    : true;
+                token.funct = funct;
+                global_scope[name] = token;
             }
+            if (kind === 'becoming') {
+                kind = 'var';
+            }
+
+// Ordinary variables.
+
         } else {
-            scope[symbol] = funct;
+
+// Warn if the variable already exists.
+
+            if (typeof funct[name] === 'string') {
+                if (funct[name] === 'undef') {
+                    if (!option.undef) {
+                        warn('used_before_a', token, name);
+                    }
+                    kind = 'var';
+                } else {
+                    warn('already_defined', token, name);
+                }
+            } else {
+
+// Add the symbol to the current function.
+
+                token.funct = funct;
+                token.writeable = true;
+                scope[name] = token;
+            }
         }
+        funct[name] = kind;
     }
 
 
@@ -2313,34 +2183,13 @@ klass:                                  do {
     }
 
 
-    function discard(it) {
-
-// The token will not be included in the parse tree, so move the comments
-// that are attached to the token to tokens that are in the tree.
-
-        it = it || token;
-        if (it.comments) {
-            var prev = it.prev;
-            while (prev.comments === null) {
-                prev = prev.prev;
-            }
-            if (prev.comments) {
-                prev.comments = prev.comments.concat(it.comments);
-            } else {
-                prev.comments = it.comments;
-            }
-        }
-        it.comments = null;
-    }
-
-
     function advance(id, match) {
 
 // Produce the next token, also looking for programming errors.
 
         if (indent) {
 
-// In indentation checking was requested, then inspect all of the line breakings.
+// If indentation checking was requested, then inspect all of the line breakings.
 // The var statement is tricky because the names might be aligned or not. We
 // look at the first line break after the var to determine the programmer's
 // intention.
@@ -2359,7 +2208,11 @@ klass:                                  do {
                     }
                     dent.open = false;
                 }
-                var_mode = false;
+                var_mode = null;
+            }
+            if (next_token.id === '?' && indent.mode === ':' &&
+                    token.line !== next_token.line) {
+                indent.at -= option.indent;
             }
             if (indent.open) {
 
@@ -2415,39 +2268,197 @@ klass:                                  do {
             }
             break;
         }
-        if (token.arity === 'string' || token.identifier) {
-            anonname = token.value;
+        if (token.id === '(string)' || token.identifier) {
+            anonname = token.string;
         }
 
         if (id && next_token.id !== id) {
             if (match) {
                 warn('expected_a_b_from_c_d', next_token, id,
-                    match.id, match.line, next_token.value);
-            } else if (!next_token.identifier || next_token.value !== id) {
-                warn('expected_a_b', next_token, id, next_token.value);
+                    match.id, match.line, artifact());
+            } else if (!next_token.identifier || next_token.string !== id) {
+                warn('expected_a_b', next_token, id, artifact());
             }
         }
         prev_token = token;
         token = next_token;
         next_token = lookahead.shift() || lex.token();
-        if (token.id === '(end)') {
-            discard();
+    }
+
+
+    function advance_identifier(string) {
+        if (next_token.identifier && next_token.string === string) {
+            advance();
+        } else {
+            warn('expected_a_b', next_token, string, artifact());
         }
     }
 
 
-    function directive() {
-        var command = this.id,
-            name,
-            old_comments_off = comments_off,
-            old_option_white = option.white,
-            value;
-        if (next_token.line === token.line && next_token.from === token.thru) {
-            warn('missing_space_a_b', next_token, token.value, next_token.value);
+    function do_safe() {
+        if (option.adsafe) {
+            option.safe = true;
         }
+        if (option.safe) {
+            option.browser     =
+                option['continue'] =
+                option.css     =
+                option.debug   =
+                option.devel   =
+                option.evil    =
+                option.forin   =
+                option.newcap  =
+                option.nomen   =
+                option.on      =
+                option.rhino   =
+                option.sloppy  =
+                option.sub     =
+                option.undef   =
+                option.widget  =
+                option.windows = false;
+
+
+            delete predefined.Array;
+            delete predefined.Date;
+            delete predefined.Function;
+            delete predefined.Object;
+            delete predefined['eval'];
+
+            add_to_predefined({
+                ADSAFE: false,
+                lib: false
+            });
+        }
+    }
+
+
+    function do_globals() {
+        var name, writeable;
+        for (;;) {
+            if (next_token.id !== '(string)' && !next_token.identifier) {
+                return;
+            }
+            name = next_token.string;
+            advance();
+            writeable = false;
+            if (next_token.id === ':') {
+                advance(':');
+                switch (next_token.id) {
+                case 'true':
+                    writeable = predefined[name] !== false;
+                    advance('true');
+                    break;
+                case 'false':
+                    advance('false');
+                    break;
+                default:
+                    stop('unexpected_a');
+                }
+            }
+            predefined[name] = writeable;
+            if (next_token.id !== ',') {
+                return;
+            }
+            advance(',');
+        }
+    }
+
+
+    function do_jslint() {
+        var name, value;
+        while (next_token.id === '(string)' || next_token.identifier) {
+            name = next_token.string;
+            advance();
+            if (next_token.id !== ':') {
+                stop('expected_a_b', next_token, ':', artifact());
+            }
+            advance(':');
+            if (typeof jslint_limit[name] === 'number') {
+                value = next_token.number;
+                if (value > jslint_limit[name] || value <= 0 ||
+                        Math.floor(value) !== value) {
+                    stop('expected_small_a');
+                }
+                option[name] = value;
+            } else {
+                if (next_token.id === 'true') {
+                    option[name] = true;
+                } else if (next_token.id === 'false') {
+                    option[name] = false;
+                } else {
+                    stop('unexpected_a');
+                }
+                switch (name) {
+                case 'adsafe':
+                    option.safe = true;
+                    do_safe();
+                    break;
+                case 'safe':
+                    do_safe();
+                    break;
+                }
+            }
+            advance();
+            if (next_token.id === ',') {
+                advance(',');
+            }
+        }
+        assume();
+    }
+
+
+    function do_properties() {
+        var name, type;
+        option.properties = true;
+        if (!funct['(old_property_type)']) {
+            funct['(old_property_type)'] = property_type;
+            property_type = Object.create(property_type);
+        }
+        for (;;) {
+            if (next_token.id !== '(string)' && !next_token.identifier) {
+                return;
+            }
+            name = next_token.string;
+            type = '';
+            advance();
+            if (next_token.id === ':') {
+                advance(':');
+                if (next_token.id === 'function') {
+                    advance('function');
+                    if (is_type[next_token.string] === true) {
+                        type = 'function ' + next_token.string;
+                        advance();
+                    } else {
+                        type = 'function';
+                    }
+                } else {
+                    type = next_token.string;
+                    if (is_type[type] !== true) {
+                        warn('expected_type_a', next_token);
+                        type = '';
+                    }
+                    advance();
+                }
+            }
+            property_type[name] = type;
+            if (next_token.id !== ',') {
+                return;
+            }
+            advance(',');
+        }
+    }
+
+
+    directive = function directive() {
+        var command = this.id,
+            old_comments_off = comments_off,
+            old_indent = indent;
         comments_off = true;
-        option.white = false;
-        if (lookahead.length > 0 || next_token.comments) {
+        indent = null;
+        if (next_token.line === token.line && next_token.from === token.thru) {
+            warn('missing_space_a_b', next_token, artifact(token), artifact());
+        }
+        if (lookahead.length > 0) {
             warn('unexpected_a', this);
         }
         switch (command) {
@@ -2455,157 +2466,44 @@ klass:                                  do {
         case '/*property':
         case '/*members':
         case '/*member':
-            command = '/*properties';
-            if (!properties) {
-                properties = {};
-            }
+            do_properties();
             break;
         case '/*jslint':
             if (option.safe) {
                 warn('adsafe_a', this);
             }
+            do_jslint();
             break;
         case '/*globals':
         case '/*global':
-            command = '/*global';
             if (option.safe) {
                 warn('adsafe_a', this);
             }
+            do_globals();
             break;
         default:
-            stop('unpexpected_a', this);
-        }
-loop:   for (;;) {
-            for (;;) {
-                if (next_token.id === '*/') {
-                    break loop;
-                }
-                if (next_token.id !== ',') {
-                    break;
-                }
-                advance();
-            }
-            if (next_token.arity !== 'string' && !next_token.identifier) {
-                stop('unexpected_a', next_token);
-            }
-            name = next_token.value;
-            advance();
-            switch (command) {
-            case '/*global':
-                if (next_token.id === ':') {
-                    advance(':');
-                    switch (next_token.id) {
-                    case 'true':
-                        if (typeof scope[name] === 'object' ||
-                                global[name] === false) {
-                            stop('unexpected_a');
-                        }
-                        global[name] = true;
-                        advance('true');
-                        break;
-                    case 'false':
-                        if (typeof scope[name] === 'object') {
-                            stop('unexpected_a');
-                        }
-                        global[name] = false;
-                        advance('false');
-                        break;
-                    default:
-                        stop('unexpected_a');
-                    }
-                } else {
-                    if (typeof scope[name] === 'object') {
-                        stop('unexpected_a');
-                    }
-                    global[name] = false;
-                }
-                break;
-            case '/*jslint':
-                if (next_token.id !== ':') {
-                    stop('expected_a_b', next_token, ':', next_token.value);
-                }
-                advance(':');
-                switch (name) {
-                case 'indent':
-                    value = +next_token.value;
-                    if (typeof value !== 'number' ||
-                            !isFinite(value) || value < 0 ||
-                            Math.floor(value) !== value) {
-                        stop('expected_small_a');
-                    }
-                    if (value > 0) {
-                        old_option_white = true;
-                    }
-                    option.indent = value;
-                    break;
-                case 'maxerr':
-                    value = +next_token.value;
-                    if (typeof value !== 'number' ||
-                            !isFinite(value) ||
-                            value <= 0 ||
-                            Math.floor(value) !== value) {
-                        stop('expected_small_a', next_token);
-                    }
-                    option.maxerr = value;
-                    break;
-                case 'maxlen':
-                    value = +next_token.value;
-                    if (typeof value !== 'number' || !isFinite(value) || value < 0 ||
-                            Math.floor(value) !== value) {
-                        stop('expected_small_a');
-                    }
-                    option.maxlen = value;
-                    break;
-                case 'white':
-                    if (next_token.id === 'true') {
-                        old_option_white = true;
-                    } else if (next_token.id === 'false') {
-                        old_option_white = false;
-                    } else {
-                        stop('unexpected_a');
-                    }
-                    break;
-                default:
-                    if (next_token.id === 'true') {
-                        option[name] = true;
-                    } else if (next_token.id === 'false') {
-                        option[name] = false;
-                    } else {
-                        stop('unexpected_a');
-                    }
-                }
-                advance();
-                break;
-            case '/*properties':
-                properties[name] = true;
-                break;
-            default:
-                stop('unexpected_a');
-            }
-        }
-        if (command === '/*jslint') {
-            assume();
+            stop('unexpected_a', this);
         }
         comments_off = old_comments_off;
         advance('*/');
-        option.white = old_option_white;
-    }
+        indent = old_indent;
+    };
 
 
 // Indentation intention
 
     function edge(mode) {
-        next_token.edge = !indent || (indent.open && (mode || true));
+        next_token.edge = indent ? indent.open && (mode || 'edge') : '';
     }
 
 
     function step_in(mode) {
-        var open, was;
+        var open;
         if (typeof mode === 'number') {
             indent = {
-                at: mode,
+                at: +mode,
                 open: true,
-                was: was
+                was: indent
             };
         } else if (!indent) {
             indent = {
@@ -2614,16 +2512,15 @@ loop:   for (;;) {
                 open: true
             };
         } else {
-            was = indent;
             open = mode === 'var' ||
                 (next_token.line !== token.line && mode !== 'statement');
             indent = {
-                at: (open || mode === 'control' ?
-                    was.at + option.indent : was.at) +
-                    (was.wrap ? option.indent : 0),
+                at: (open || mode === 'control'
+                    ? indent.at + option.indent
+                    : indent.at) + (indent.wrap ? option.indent : 0),
                 mode: mode,
                 open: open,
-                was: was
+                was: indent
             };
             if (mode === 'var' && open) {
                 var_mode = indent;
@@ -2649,10 +2546,10 @@ loop:   for (;;) {
     function one_space(left, right) {
         left = left || token;
         right = right || next_token;
-        if (right.id !== '(end)' && option.white &&
+        if (right.id !== '(end)' && !option.white &&
                 (token.line !== right.line ||
                 token.thru + 1 !== right.from)) {
-            warn('expected_space_a_b', right, token.value, right.value);
+            warn('expected_space_a_b', right, artifact(token), artifact(right));
         }
     }
 
@@ -2660,17 +2557,17 @@ loop:   for (;;) {
         left = left || token;
         right = right || next_token;
         if (right.id !== '(end)' && (left.line !== right.line ||
-                (option.white && left.thru + 1 !== right.from))) {
-            warn('expected_space_a_b', right, left.value, right.value);
+                (!option.white && left.thru + 1 !== right.from))) {
+            warn('expected_space_a_b', right, artifact(left), artifact(right));
         }
     }
 
     function no_space(left, right) {
         left = left || token;
         right = right || next_token;
-        if ((option.white || xmode === 'styleproperty' || xmode === 'style') &&
+        if ((!option.white || xmode === 'styleproperty' || xmode === 'style') &&
                 left.thru !== right.from && left.line === right.line) {
-            warn('unexpected_space_a_b', right, left.value, right.value);
+            warn('unexpected_space_a_b', right, artifact(left), artifact(right));
         }
     }
 
@@ -2678,30 +2575,29 @@ loop:   for (;;) {
         left = left || token;
         right = right || next_token;
         if (right.id !== '(end)' && (left.line !== right.line ||
-                (option.white && left.thru !== right.from))) {
-            warn('unexpected_space_a_b', right, left.value, right.value);
+                (!option.white && left.thru !== right.from))) {
+            warn('unexpected_space_a_b', right, artifact(left), artifact(right));
         }
     }
 
     function spaces(left, right) {
-        if (option.white) {
+        if (!option.white) {
             left = left || token;
             right = right || next_token;
             if (left.thru === right.from && left.line === right.line) {
-                warn('missing_space_a_b', right, left.value, right.value);
+                warn('missing_space_a_b', right, artifact(left), artifact(right));
             }
         }
     }
 
     function comma() {
         if (next_token.id !== ',') {
-            warn_at('expected_a_b', token.line, token.thru, ',', next_token.value);
+            warn_at('expected_a_b', token.line, token.thru, ',', artifact());
         } else {
-            if (option.white) {
+            if (!option.white) {
                 no_space_only();
             }
             advance(',');
-            discard();
             spaces();
         }
     }
@@ -2709,13 +2605,12 @@ loop:   for (;;) {
 
     function semicolon() {
         if (next_token.id !== ';') {
-            warn_at('expected_a_b', token.line, token.thru, ';', next_token.value);
+            warn_at('expected_a_b', token.line, token.thru, ';', artifact());
         } else {
-            if (option.white) {
+            if (!option.white) {
                 no_space_only();
             }
             advance(';');
-            discard();
             if (semicolon_coda[next_token.id] !== true) {
                 spaces();
             }
@@ -2723,7 +2618,7 @@ loop:   for (;;) {
     }
 
     function use_strict() {
-        if (next_token.value === 'use strict') {
+        if (next_token.string === 'use strict') {
             if (strict_mode) {
                 warn('unnecessary_use');
             }
@@ -2731,8 +2626,8 @@ loop:   for (;;) {
             advance();
             semicolon();
             strict_mode = true;
-            option.newcap = true;
-            option.undef = true;
+            option.newcap = false;
+            option.undef = false;
             return true;
         } else {
             return false;
@@ -2759,12 +2654,15 @@ loop:   for (;;) {
         if (Array.isArray(b)) {
             return false;
         }
-        if (a.arity === b.arity && a.value === b.value) {
+        if (a.id === '(number)' && b.id === '(number)') {
+            return a.number === b.number;
+        }
+        if (a.arity === b.arity && a.string === b.string) {
             switch (a.arity) {
             case 'prefix':
             case 'suffix':
             case undefined:
-                return are_similar(a.first, b.first);
+                return a.id === b.id && are_similar(a.first, b.first);
             case 'infix':
                 return are_similar(a.first, b.first) &&
                     are_similar(a.second, b.second);
@@ -2780,9 +2678,9 @@ loop:   for (;;) {
             }
         } else {
             if (a.id === '.' && b.id === '[' && b.arity === 'infix') {
-                return a.second.value === b.second.value && b.second.arity === 'string';
+                return a.second.string === b.second.string && b.second.id === '(string)';
             } else if (a.id === '[' && a.arity === 'infix' && b.id === '.') {
-                return a.second.value === b.second.value && a.second.arity === 'string';
+                return a.second.string === b.second.string && a.second.id === '(string)';
             }
         }
         return false;
@@ -2813,13 +2711,14 @@ loop:   for (;;) {
             stop('unexpected_a', token, next_token.id);
         }
         advance();
-        if (option.safe && typeof predefined[token.value] === 'boolean' &&
+        if (option.safe && scope[token.string] &&
+                scope[token.string] === global_scope[token.string] &&
                 (next_token.id !== '(' && next_token.id !== '.')) {
-            warn('adsafe', token);
+            warn('adsafe_a', token);
         }
         if (initial) {
             anonname = 'anonymous';
-            funct['(verb)'] = token.value;
+            funct['(verb)'] = token.string;
         }
         if (initial === true && token.fud) {
             left = token.fud();
@@ -2827,9 +2726,8 @@ loop:   for (;;) {
             if (token.nud) {
                 left = token.nud();
             } else {
-                if (next_token.arity === 'number' && token.id === '.') {
-                    warn('leading_decimal_a', token,
-                        next_token.value);
+                if (next_token.id === '(number)' && token.id === '.') {
+                    warn('leading_decimal_a', token, artifact());
                     advance();
                     return token;
                 } else {
@@ -2857,18 +2755,12 @@ loop:   for (;;) {
         if (!x || typeof x !== 'object') {
             syntax[s] = x = {
                 id: s,
-                lbp: p,
-                value: s
+                lbp: p || 0,
+                string: s
             };
         }
         return x;
     }
-
-
-    function delim(s) {
-        return symbol(s, 0);
-    }
-
 
     function postscript(x) {
         x.postscript = true;
@@ -2880,14 +2772,14 @@ loop:   for (;;) {
         x.from = 1;
         x.thru = 1;
         x.line = 0;
-        x.edge = true;
-        s.value = s;
+        x.edge = 'edge';
+        s.string = s;
         return postscript(x);
     }
 
 
     function stmt(s, f) {
-        var x = delim(s);
+        var x = symbol(s);
         x.identifier = x.reserved = true;
         x.fud = f;
         return x;
@@ -2913,34 +2805,37 @@ loop:   for (;;) {
     }
 
 
-    function prefix(s, f) {
+    function prefix(s, f, type) {
         var x = symbol(s, 150);
         reserve_name(x);
-        x.nud = (typeof f === 'function') ? f : function () {
-            if (s === 'typeof') {
-                one_space();
-            } else {
-                no_space_only();
-            }
-            this.first = expression(150);
-            this.arity = 'prefix';
-            if (this.id === '++' || this.id === '--') {
-                if (option.plusplus) {
-                    warn('unexpected_a', this);
-                } else if ((!this.first.identifier || this.first.reserved) &&
-                        this.first.id !== '.' && this.first.id !== '[') {
-                    warn('bad_operand', this);
+        x.nud = typeof f === 'function'
+            ? f
+            : function () {
+                if (s === 'typeof') {
+                    one_space();
+                } else {
+                    no_space_only();
                 }
-            }
-            return this;
-        };
+                this.first = expression(150);
+                this.arity = 'prefix';
+                if (this.id === '++' || this.id === '--') {
+                    if (!option.plusplus) {
+                        warn('unexpected_a', this);
+                    } else if ((!this.first.identifier || this.first.reserved) &&
+                            this.first.id !== '.' && this.first.id !== '[') {
+                        warn('bad_operand', this);
+                    }
+                }
+                this.type = type;
+                return this;
+            };
         return x;
     }
 
 
-    function type(s, arity, nud) {
-        var x = delim(s);
-        x.arity = arity;
+    function type(s, t, nud) {
+        var x = symbol(s);
+        x.arity = x.type = t;
         if (nud) {
             x.nud = nud;
         }
@@ -2949,11 +2844,20 @@ loop:   for (;;) {
 
 
     function reserve(s, f) {
-        var x = delim(s);
+        var x = symbol(s);
         x.identifier = x.reserved = true;
         if (typeof f === 'function') {
             x.nud = f;
         }
+        return x;
+    }
+
+
+    function constant(name, type) {
+        var x = reserve(name);
+        x.type = type;
+        x.string = name;
+        x.nud = return_this;
         return x;
     }
 
@@ -2968,7 +2872,7 @@ loop:   for (;;) {
     }
 
 
-    function infix(s, p, f, w) {
+    function infix(s, p, f, type, w) {
         var x = symbol(s, p);
         reserve_name(x);
         x.led = function (left) {
@@ -2976,6 +2880,9 @@ loop:   for (;;) {
             if (!w) {
                 spaces(prev_token, token);
                 spaces();
+            }
+            if (!option.bitwise && this.bitwise) {
+                warn('unexpected_a', this);
             }
             if (typeof f === 'function') {
                 return f(left, this);
@@ -2985,6 +2892,9 @@ loop:   for (;;) {
                 return this;
             }
         };
+        if (type) {
+            x.type = type;
+        }
         return x;
     }
 
@@ -3018,7 +2928,7 @@ loop:   for (;;) {
             warn(message || bundle.weird_condition, node);
             break;
         case '(':
-            if (node.first.id === '.' && numbery[node.first.second.value] === true) {
+            if (node.first.id === '.' && numbery[node.first.second.string] === true) {
                 warn(message || bundle.weird_condition, node);
             }
             break;
@@ -3053,86 +2963,82 @@ loop:   for (;;) {
 
 
     function relation(s, eqeq) {
-        var x = infix(s, 100, function (left, that) {
+        return infix(s, 100, function (left, that) {
             check_relation(left);
-            if (eqeq) {
+            if (eqeq && !option.eqeq) {
                 warn('expected_a_b', that, eqeq, that.id);
             }
             var right = expression(100);
             if (are_similar(left, right) ||
-                    ((left.arity === 'string' || left.arity === 'number') &&
-                    (right.arity === 'string' || right.arity === 'number'))) {
+                    ((left.id === '(string)' || left.id === '(number)') &&
+                    (right.id === '(string)' || right.id === '(number)'))) {
                 warn('weird_relation', that);
             }
             that.first = left;
             that.second = check_relation(right);
             return that;
-        });
-        return x;
+        }, 'boolean');
     }
 
 
-    function assignop(s, bit) {
+    function assignop(s, op) {
         var x = infix(s, 20, function (left, that) {
             var l;
-            if (option.bitwise && bit) {
-                warn('unexpected_a', that);
-            }
             that.first = left;
-            if (funct[left.value] === false) {
-                warn('read_only', left);
-            } else if (left['function']) {
-                warn('a_function', left);
-            }
-            if (option.safe) {
+            if (left.identifier) {
+                if (scope[left.string]) {
+                    if (scope[left.string].writeable === false) {
+                        warn('read_only', left);
+                    }
+                } else {
+                    stop('read_only');
+                }
+            } else if (option.safe) {
                 l = left;
                 do {
-                    if (typeof predefined[l.value] === 'boolean') {
-                        warn('adsafe', l);
+                    if (typeof predefined[l.string] === 'boolean') {
+                        warn('adsafe_a', l);
                     }
                     l = l.first;
                 } while (l);
             }
-            if (left) {
-                if (left === syntax['function']) {
-                    warn('identifier_function', token);
-                }
-                if (left.id === '.' || left.id === '[') {
-                    if (!left.first || left.first.value === 'arguments') {
-                        warn('bad_assignment', that);
-                    }
-                    that.second = expression(19);
-                    if (that.id === '=' && are_similar(that.first, that.second)) {
-                        warn('weird_assignment', that);
-                    }
-                    return that;
-                } else if (left.identifier && !left.reserved) {
-                    if (funct[left.value] === 'exception') {
-                        warn('assign_exception', left);
-                    }
-                    that.second = expression(19);
-                    if (that.id === '=' && are_similar(that.first, that.second)) {
-                        warn('weird_assignment', that);
-                    }
-                    return that;
-                }
+            if (left === syntax['function']) {
+                warn('identifier_function', token);
             }
-            stop('bad_assignment', that);
+            if (left.id === '.' || left.id === '[') {
+                if (!left.first || left.first.string === 'arguments') {
+                    warn('bad_assignment', that);
+                }
+            } else if (left.identifier) {
+                if (!left.reserved && funct[left.string] === 'exception') {
+                    warn('assign_exception', left);
+                }
+            } else {
+                warn('bad_assignment', that);
+            }
+            that.second = expression(19);
+            if (that.id === '=' && are_similar(that.first, that.second)) {
+                warn('weird_assignment', that);
+            }
+            return that;
         });
         x.assign = true;
+        if (op) {
+            if (syntax[op].type) {
+                x.type = syntax[op].type;
+            }
+            if (syntax[op].bitwise) {
+                x.bitwise = true;
+            }
+        }
         return x;
     }
 
 
     function bitwise(s, p) {
-        return infix(s, p, function (left, that) {
-            if (option.bitwise) {
-                warn('unexpected_a', that);
-            }
-            that.first = left;
-            that.second = expression(p);
-            return that;
-        });
+        var x = infix(s, p, 'number');
+        x.bitwise = true;
+        return x;
     }
 
 
@@ -3140,7 +3046,7 @@ loop:   for (;;) {
         var x = symbol(s, 150);
         x.led = function (left) {
             no_space_only(prev_token, token);
-            if (option.plusplus) {
+            if (!option.plusplus) {
                 warn('unexpected_a', this);
             } else if ((!left.identifier || left.reserved) &&
                     left.id !== '.' && left.id !== '[') {
@@ -3157,33 +3063,28 @@ loop:   for (;;) {
     function optional_identifier() {
         if (next_token.identifier) {
             advance();
-            if (option.safe && banned[token.value]) {
+            if (option.safe && banned[token.string]) {
                 warn('adsafe_a', token);
             } else if (token.reserved && !option.es5) {
                 warn('expected_identifier_a_reserved', token);
             }
-            return token.value;
+            return token.string;
         }
     }
 
 
     function identifier() {
         var i = optional_identifier();
-        if (i) {
-            return i;
+        if (!i) {
+            stop(token.id === 'function' && next_token.id === '('
+                ? 'name_function'
+                : 'expected_identifier_a');
         }
-        if (token.id === 'function' && next_token.id === '(') {
-            warn('name_function');
-        } else {
-            stop('expected_identifier_a');
-        }
+        return i;
     }
 
 
     function statement() {
-
-// Usually a statement starts a line. Exceptions include the var statement in the
-// initialization part of a for statement, and an if after an else.
 
         var label, old_scope = scope, the_statement;
 
@@ -3201,16 +3102,15 @@ loop:   for (;;) {
             edge('label');
             label = next_token;
             advance();
-            discard();
             advance(':');
-            discard();
             scope = Object.create(old_scope);
-            add_label(label.value, 'label');
+            add_label(label, 'label');
             if (next_token.labeled !== true) {
-                warn('label_a_b', next_token, label.value, next_token.value);
-            }
-            if (jx.test(label.value + ':')) {
+                warn('label_a_b', next_token, label.string, artifact());
+            } else if (jx.test(label.string + ':')) {
                 warn('url', label);
+            } else if (funct === global_funct) {
+                stop('unexpected_a', token);
             }
             next_token.label = label;
         }
@@ -3233,7 +3133,7 @@ loop:   for (;;) {
                 }
             } else {
 
-// If this is an expression statement, determine if it is acceptble.
+// If this is an expression statement, determine if it is acceptable.
 // We do not like
 //      new Blah();
 // statments. If it is to be used at all, new should only be used to make
@@ -3270,9 +3170,15 @@ loop:   for (;;) {
                 warn('unexpected_a', next_token);
                 semicolon();
             } else {
+                if (next_token.string === 'use strict') {
+                    if ((!node_js && xmode !== 'script') || funct !== global_funct || array.length > 0) {
+                        warn('function_strict');
+                    }
+                    use_strict();
+                }
                 if (disruptor) {
-                    warn('unreachable_a_b', next_token, next_token.value,
-                        disruptor.value);
+                    warn('unreachable_a_b', next_token, next_token.string,
+                        disruptor.string);
                     disruptor = null;
                 }
                 the_statement = statement();
@@ -3297,7 +3203,7 @@ loop:   for (;;) {
 
         var array,
             curly = next_token,
-            old_inblock = in_block,
+            old_in_block = in_block,
             old_scope = scope,
             old_strict_mode = strict_mode;
 
@@ -3308,23 +3214,22 @@ loop:   for (;;) {
             advance('{');
             step_in();
             if (!ordinary && !use_strict() && !old_strict_mode &&
-                    option.strict && funct['(context)']['(global)']) {
+                    !option.sloppy && funct['(context)'] === global_funct) {
                 warn('missing_use_strict');
             }
             array = statements();
             strict_mode = old_strict_mode;
             step_out('}', curly);
-            discard();
         } else if (!ordinary) {
-            stop('expected_a_b', next_token, '{', next_token.value);
+            stop('expected_a_b', next_token, '{', artifact());
         } else {
-            warn('expected_a_b', next_token, '{', next_token.value);
+            warn('expected_a_b', next_token, '{', artifact());
             array = [statement()];
             array.disrupt = array[0].disrupt;
         }
         funct['(verb)'] = null;
         scope = old_scope;
-        in_block = old_inblock;
+        in_block = old_in_block;
         if (ordinary && array.length === 0) {
             warn('empty_block');
         }
@@ -3333,7 +3238,7 @@ loop:   for (;;) {
 
 
     function tally_property(name) {
-        if (properties && typeof properties[name] !== 'boolean') {
+        if (option.properties && typeof property_type[name] !== 'string') {
             warn('unexpected_property_a', token, name);
         }
         if (typeof member[name] === 'number') {
@@ -3344,32 +3249,49 @@ loop:   for (;;) {
     }
 
 
-    function note_implied(token) {
-        var name = token.value, line = token.line, a = implied[name];
-        if (typeof a === 'function') {
-            a = false;
-        }
-        if (!a) {
-            a = [line];
-            implied[name] = a;
-        } else if (a[a.length - 1] !== line) {
-            a.push(line);
-        }
-    }
-
-
 // ECMAScript parser
 
     syntax['(identifier)'] = {
-        type: '(identifier)',
+        id: '(identifier)',
         lbp: 0,
         identifier: true,
         nud: function () {
-            var variable = this.value,
-                site = scope[variable];
-            if (typeof site === 'function') {
-                site = undefined;
+            var name = this.string,
+                variable = scope[name],
+                site,
+                writeable;
+
+// If the variable is not in scope, then we may have an undeclared variable.
+// Check the predefined list. If it was predefined, create the global
+// variable.
+
+            if (typeof variable !== 'object') {
+                writeable = predefined[name];
+                if (typeof writeable === 'boolean') {
+                    global_scope[name] = variable = {
+                        string:    name,
+                        writeable: writeable,
+                        funct:     global_funct
+                    };
+                    global_funct[name] = 'var';
+
+// But if the variable is not in scope, and is not predefined, and if we are not
+// in the global scope, then we have an undefined variable error.
+
+                } else {
+                    if (!option.undef) {
+                        warn('used_before_a', token);
+                    }
+                    scope[name] = variable = {
+                        string: name,
+                        writeable: true,
+                        funct: funct
+                    };
+                    funct[name] = 'undef';
+                }
+
             }
+            site = variable.funct;
 
 // The name is in scope and defined in the current function.
 
@@ -3377,105 +3299,70 @@ loop:   for (;;) {
 
 //      Change 'unused' to 'var', and reject labels.
 
-                switch (funct[variable]) {
-                case 'error':
+                switch (funct[name]) {
+                case 'becoming':
                     warn('unexpected_a', token);
-                    funct[variable] = 'var';
+                    funct[name] = 'var';
                     break;
                 case 'unused':
-                    funct[variable] = 'var';
+                    funct[name] = 'var';
                     break;
                 case 'unparam':
-                    funct[variable] = 'parameter';
+                    funct[name] = 'parameter';
                     break;
                 case 'unction':
-                    funct[variable] = 'function';
-                    this['function'] = true;
-                    break;
-                case 'function':
-                    this['function'] = true;
+                    funct[name] = 'function';
                     break;
                 case 'label':
-                    warn('a_label', token, variable);
+                    warn('a_label', token, name);
                     break;
-                }
-
-// The name is not defined in the function.  If we are in the global scope,
-// then we have an undefined variable.
-
-            } else if (funct['(global)']) {
-                if (typeof global[variable] === 'boolean') {
-                    funct[variable] = global[variable];
-                } else {
-                    if (option.undef) {
-                        warn('not_a_defined', token, variable);
-                    } else {
-                        note_implied(token);
-                    }
                 }
 
 // If the name is already defined in the current
 // function, but not as outer, then there is a scope error.
 
             } else {
-                switch (funct[variable]) {
+                switch (funct[name]) {
                 case 'closure':
                 case 'function':
                 case 'var':
                 case 'unused':
-                    warn('a_scope', token, variable);
+                    warn('a_scope', token, name);
                     break;
                 case 'label':
-                    warn('a_label', token, variable);
+                    warn('a_label', token, name);
                     break;
                 case 'outer':
-                case true:
-                case false:
+                case 'global':
                     break;
                 default:
 
 // If the name is defined in an outer function, make an outer entry, and if
 // it was unused, make it var.
 
-                    if (typeof site === 'boolean') {
-                        funct[variable] = site;
-                        functions[0][variable] = true;
-                    } else if (site === null) {
-                        warn('a_not_allowed', token, variable);
-                        note_implied(token);
-                    } else if (typeof site !== 'object') {
-                        if (option.undef) {
-                            warn('a_not_defined', token, variable);
-                        } else {
-                            funct[variable] = true;
-                        }
-                        note_implied(token);
-                    } else {
-                        switch (site[variable]) {
-                        case 'function':
-                        case 'unction':
-                            this['function'] = true;
-                            site[variable] = 'closure';
-                            funct[variable] = site['(global)'] ? false : 'outer';
-                            break;
-                        case 'var':
-                        case 'unused':
-                        case 'closure':
-                        case 'parameter':
-                            site[variable] = 'closure';
-                            funct[variable] = site['(global)'] ? true : 'outer';
-                            break;
-                        case 'unparam':
-                            site[variable] = 'parameter';
-                            funct[variable] = site['(global)'] ? false : 'outer';
-                            break;
-                        case 'error':
-                            warn('not_a_defined', token);
-                            break;
-                        case 'label':
-                            warn('a_label', token, variable);
-                            break;
-                        }
+                    switch (site[name]) {
+                    case 'becoming':
+                    case 'closure':
+                    case 'function':
+                    case 'parameter':
+                    case 'unction':
+                    case 'unused':
+                    case 'var':
+                        site[name] = 'closure';
+                        funct[name] = site === global_funct
+                            ? 'global'
+                            : 'outer';
+                        break;
+                    case 'unparam':
+                        site[name] = 'parameter';
+                        funct[name] = 'outer';
+                        break;
+                    case 'undef':
+                        funct[name] = 'undef';
+                        break;
+                    case 'label':
+                        warn('a_label', token, name);
+                        break;
                     }
                 }
             }
@@ -3488,30 +3375,34 @@ loop:   for (;;) {
 
 // Build the syntax table by declaring the syntactic elements.
 
+    type('(array)', 'array');
     type('(color)', 'color');
+    type('(function)', 'function');
     type('(number)', 'number', return_this);
+    type('(object)', 'object');
     type('(string)', 'string', return_this);
+    type('(boolean)', 'boolean', return_this);
     type('(range)', 'range');
     type('(regexp)', 'regexp', return_this);
 
     ultimate('(begin)');
     ultimate('(end)');
     ultimate('(error)');
-    postscript(delim('</'));
-    delim('<!');
-    delim('<!--');
-    delim('-->');
-    postscript(delim('}'));
-    delim(')');
-    delim(']');
-    postscript(delim('"'));
-    postscript(delim('\''));
-    delim(';');
-    delim(':');
-    delim(',');
-    delim('#');
-    delim('@');
-    delim('*/');
+    postscript(symbol('</'));
+    symbol('<!');
+    symbol('<!--');
+    symbol('-->');
+    postscript(symbol('}'));
+    symbol(')');
+    symbol(']');
+    postscript(symbol('"'));
+    postscript(symbol('\''));
+    symbol(';');
+    symbol(':');
+    symbol(',');
+    symbol('#');
+    symbol('@');
+    symbol('*/');
     postscript(reserve('case'));
     reserve('catch');
     postscript(reserve('default'));
@@ -3519,59 +3410,50 @@ loop:   for (;;) {
     reserve('finally');
 
     reservevar('arguments', function (x) {
-        if (strict_mode && funct['(global)']) {
+        if (strict_mode && funct === global_funct) {
             warn('strict', x);
         } else if (option.safe) {
-            warn('adsafe', x);
+            warn('adsafe_a', x);
         }
     });
     reservevar('eval', function (x) {
         if (option.safe) {
-            warn('adsafe', x);
+            warn('adsafe_a', x);
         }
     });
-    reservevar('false');
-    reservevar('Infinity');
-    reservevar('NaN');
-    reservevar('null');
+    constant('false', 'boolean');
+    constant('Infinity', 'number');
+    constant('NaN', 'number');
+    constant('null', '');
     reservevar('this', function (x) {
-        if (strict_mode && ((funct['(statement)'] &&
-                funct['(name)'].charAt(0) > 'Z') || funct['(global)'])) {
+        if (option.safe) {
+            warn('adsafe_a', x);
+        } else if (strict_mode && funct['(token)'].arity === 'statement' &&
+                funct['(name)'].charAt(0) > 'Z') {
             warn('strict', x);
-        } else if (option.safe) {
-            warn('adsafe', x);
         }
     });
-    reservevar('true');
-    reservevar('undefined');
-
-    assignop('=');
-    assignop('+=');
-    assignop('-=');
-    assignop('*=');
-    assignop('/=').nud = function () {
-        stop('slash_equal');
-    };
-    assignop('%=');
-    assignop('&=', true);
-    assignop('|=', true);
-    assignop('^=', true);
-    assignop('<<=', true);
-    assignop('>>=', true);
-    assignop('>>>=', true);
+    constant('true', 'boolean');
+    constant('undefined', '');
 
     infix('?', 30, function (left, that) {
+        step_in('?');
         that.first = expected_condition(expected_relation(left));
         that.second = expression(0);
         spaces();
+        step_out();
+        var colon = next_token;
         advance(':');
-        discard();
+        step_in(':');
         spaces();
         that.third = expression(10);
         that.arity = 'ternary';
         if (are_similar(that.second, that.third)) {
-            warn('weird_ternary', that);
+            warn('weird_ternary', colon);
+        } else if (are_similar(that.first, that.second)) {
+            warn('use_or', that);
         }
+        step_out();
         return that;
     });
 
@@ -3602,10 +3484,13 @@ loop:   for (;;) {
 
     prefix('void', function () {
         this.first = expression(0);
-        if (this.first.arity !== 'number' || this.first.value) {
-            warn('unexpected_a', this);
-            return this;
+        this.arity = 'prefix';
+        if (option.es5) {
+            warn('expected_a_b', this, 'undefined', 'void');
+        } else if (this.first.number !== 0) {
+            warn('expected_a_b', this.first, '0', artifact(this.first));
         }
+        this.type = 'undefined';
         return this;
     });
 
@@ -3631,34 +3516,41 @@ loop:   for (;;) {
         that.left = left;
         that.right = expression(130);
         return that;
-    });
-    infix('instanceof', 120);
+    }, 'boolean');
+    infix('instanceof', 120, null, 'boolean');
     infix('+', 130, function (left, that) {
-        if (!left.value) {
-            if (left.arity === 'number') {
-                warn('unexpected_a', left);
-            } else if (left.arity === 'string') {
+        if (left.id === '(number)') {
+            if (left.number === 0) {
+                warn('unexpected_a', left, '0');
+            }
+        } else if (left.id === '(string)') {
+            if (left.string === '') {
                 warn('expected_a_b', left, 'String', '\'\'');
             }
         }
         var right = expression(130);
-        if (!right.value) {
-            if (right.arity === 'number') {
-                warn('unexpected_a', right);
-            } else if (right.arity === 'string') {
+        if (right.id === '(number)') {
+            if (right.number === 0) {
+                warn('unexpected_a', right, '0');
+            }
+        } else if (right.id === '(string)') {
+            if (right.string === '') {
                 warn('expected_a_b', right, 'String', '\'\'');
             }
         }
-        if (left.arity === right.arity &&
-                (left.arity === 'string' || left.arity === 'number')) {
-            left.value += right.value;
-            left.thru = right.thru;
-            if (left.arity === 'string' && jx.test(left.value)) {
-                warn('url', left);
+        if (left.id === right.id) {
+            if (left.id === '(string)' || left.id === '(number)') {
+                if (left.id === '(string)') {
+                    left.string += right.string;
+                    if (jx.test(left.string)) {
+                        warn('url', left);
+                    }
+                } else {
+                    left.number += right.number;
+                }
+                left.thru = right.thru;
+                return left;
             }
-            discard(right);
-            discard(that);
-            return left;
         }
         that.first = left;
         that.second = right;
@@ -3678,24 +3570,22 @@ loop:   for (;;) {
         return this;
     });
     infix('-', 130, function (left, that) {
-        if ((left.arity === 'number' && left.value === 0) || left.arity === 'string') {
+        if ((left.id === '(number)' && left.number === 0) || left.id === '(string)') {
             warn('unexpected_a', left);
         }
         var right = expression(130);
-        if ((right.arity === 'number' && right.value === 0) || right.arity === 'string') {
+        if ((right.id === '(number)' && right.number === 0) || right.id === '(string)') {
             warn('unexpected_a', left);
         }
-        if (left.arity === right.arity && left.arity === 'number') {
-            left.value -= right.value;
+        if (left.id === right.id && left.id === '(number)') {
+            left.number -= right.number;
             left.thru = right.thru;
-            discard(right);
-            discard(that);
             return left;
         }
         that.first = left;
         that.second = right;
         return that;
-    });
+    }, 'number');
     prefix('-');
     prefix('---', function () {
         warn('confusing_a', token);
@@ -3710,62 +3600,56 @@ loop:   for (;;) {
         return this;
     });
     infix('*', 140, function (left, that) {
-        if ((left.arity === 'number' && (left.value === 0 || left.value === 1)) || left.arity === 'string') {
+        if ((left.id === '(number)' && (left.number === 0 || left.number === 1)) || left.id === '(string)') {
             warn('unexpected_a', left);
         }
         var right = expression(140);
-        if ((right.arity === 'number' && (right.value === 0 || right.value === 1)) || right.arity === 'string') {
+        if ((right.id === '(number)' && (right.number === 0 || right.number === 1)) || right.id === '(string)') {
             warn('unexpected_a', right);
         }
-        if (left.arity === right.arity && left.arity === 'number') {
-            left.value *= right.value;
+        if (left.id === right.id && left.id === '(number)') {
+            left.number *= right.number;
             left.thru = right.thru;
-            discard(right);
-            discard(that);
             return left;
         }
         that.first = left;
         that.second = right;
         return that;
-    });
+    }, 'number');
     infix('/', 140, function (left, that) {
-        if ((left.arity === 'number' && left.value === 0) || left.arity === 'string') {
+        if ((left.id === '(number)' && left.number === 0) || left.id === '(string)') {
             warn('unexpected_a', left);
         }
         var right = expression(140);
-        if ((right.arity === 'number' && (right.value === 0 || right.value === 1)) || right.arity === 'string') {
+        if ((right.id === '(number)' && (right.number === 0 || right.number === 1)) || right.id === '(string)') {
             warn('unexpected_a', right);
         }
-        if (left.arity === right.arity && left.arity === 'number') {
-            left.value /= right.value;
+        if (left.id === right.id && left.id === '(number)') {
+            left.number /= right.number;
             left.thru = right.thru;
-            discard(right);
-            discard(that);
             return left;
         }
         that.first = left;
         that.second = right;
         return that;
-    });
+    }, 'number');
     infix('%', 140, function (left, that) {
-        if ((left.arity === 'number' && (left.value === 0 || left.value === 1)) || left.arity === 'string') {
+        if ((left.id === '(number)' && (left.number === 0 || left.number === 1)) || left.id === '(string)') {
             warn('unexpected_a', left);
         }
         var right = expression(140);
-        if ((right.arity === 'number' && right.value === 0) || right.arity === 'string') {
+        if ((right.id === '(number)' && right.number === 0) || right.id === '(string)') {
             warn('unexpected_a', right);
         }
-        if (left.arity === right.arity && left.arity === 'number') {
-            left.value %= right.value;
+        if (left.id === right.id && left.id === '(number)') {
+            left.number %= right.number;
             left.thru = right.thru;
-            discard(right);
-            discard(that);
             return left;
         }
         that.first = left;
         that.second = right;
         return that;
-    });
+    }, 'number');
 
     suffix('++');
     prefix('++');
@@ -3785,29 +3669,29 @@ loop:   for (;;) {
 
     prefix('~', function () {
         no_space_only();
-        if (option.bitwise) {
+        if (!option.bitwise) {
             warn('unexpected_a', this);
         }
         expression(150);
         return this;
-    });
+    }, 'number');
     prefix('!', function () {
         no_space_only();
         this.first = expected_condition(expression(150));
         this.arity = 'prefix';
-        if (bang[this.first.id] === true) {
+        if (bang[this.first.id] === true || this.first.assign) {
             warn('confusing_a', this);
         }
         return this;
-    });
-    prefix('typeof');
+    }, 'boolean');
+    prefix('typeof', null, 'string');
     prefix('new', function () {
         one_space();
-        var c = expression(160), i, p;
+        var c = expression(160), n, p, v;
         this.first = c;
         if (c.id !== 'function') {
             if (c.identifier) {
-                switch (c.value) {
+                switch (c.string) {
                 case 'Object':
                     warn('use_object', token);
                     break;
@@ -3817,25 +3701,19 @@ loop:   for (;;) {
                         p.first = this;
                         advance('(');
                         if (next_token.id !== ')') {
-                            p.second = expression(0);
-                            if (p.second.arity !== 'number' || !p.second.value) {
-                                expected_condition(p.second,  bundle.use_array);
-                                i = false;
-                            } else {
-                                i = true;
+                            n = expression(0);
+                            p.second = [n];
+                            if (n.type !== 'number' || next_token.id === ',') {
+                                warn('use_array', p);
                             }
-                            while (next_token.id !== ')' && next_token.id !== '(end)') {
-                                if (i) {
-                                    warn('use_array', p);
-                                    i = false;
-                                }
-                                advance();
+                            while (next_token.id === ',') {
+                                advance(',');
+                                p.second.push(expression(0));
                             }
                         } else {
                             warn('use_array', token);
                         }
                         advance(')', p);
-                        discard();
                         return p;
                     }
                     warn('use_array', token);
@@ -3857,8 +3735,8 @@ loop:   for (;;) {
                     break;
                 default:
                     if (c.id !== 'function') {
-                        i = c.value.substr(0, 1);
-                        if (option.newcap && (i < 'A' || i > 'Z')) {
+                        v = c.string.charAt(0);
+                        if (!option.newcap && (v < 'A' || v > 'Z')) {
                             warn('constructor_name_a', token);
                         }
                     }
@@ -3878,6 +3756,7 @@ loop:   for (;;) {
     });
 
     infix('(', 160, function (left, that) {
+        var p;
         if (indent && indent.mode === 'expression') {
             no_space(prev_token, token);
         } else {
@@ -3886,29 +3765,27 @@ loop:   for (;;) {
         if (!left.immed && left.id === 'function') {
             warn('wrap_immediate');
         }
-        var p = [];
-        if (left) {
-            if (left.identifier) {
-                if (left.value.match(/^[A-Z]([A-Z0-9_$]*[a-z][A-Za-z0-9_$]*)?$/)) {
-                    if (left.value !== 'Number' && left.value !== 'String' &&
-                            left.value !== 'Boolean' && left.value !== 'Date') {
-                        if (left.value === 'Math' || left.value === 'JSON') {
-                            warn('not_a_function', left);
-                        } else if (left.value === 'Object') {
-                            warn('use_object', token);
-                        } else if (left.value === 'Array' || option.newcap) {
-                            warn('missing_a', left, 'new');
-                        }
+        p = [];
+        if (left.identifier) {
+            if (left.string.match(/^[A-Z]([A-Z0-9_$]*[a-z][A-Za-z0-9_$]*)?$/)) {
+                if (left.string !== 'Number' && left.string !== 'String' &&
+                        left.string !== 'Boolean' && left.string !== 'Date') {
+                    if (left.string === 'Math' || left.string === 'JSON') {
+                        warn('not_a_function', left);
+                    } else if (left.string === 'Object') {
+                        warn('use_object', token);
+                    } else if (left.string === 'Array' || !option.newcap) {
+                        warn('missing_a', left, 'new');
                     }
                 }
-            } else if (left.id === '.') {
-                if (option.safe && left.first.value === 'Math' &&
-                        left.second === 'random') {
-                    warn('adsafe', left);
-                } else if (left.second.value === 'split' &&
-                        left.first.id === '(string)') {
-                    warn('use_array', left.second);
-                }
+            }
+        } else if (left.id === '.') {
+            if (option.safe && left.first.string === 'Math' &&
+                    left.second === 'random') {
+                warn('adsafe_a', left);
+            } else if (left.second.string === 'split' &&
+                    left.first.id === '(string)') {
+                warn('use_array', left.second);
             }
         }
         step_in();
@@ -3926,16 +3803,16 @@ loop:   for (;;) {
         no_space();
         step_out(')', that);
         if (typeof left === 'object') {
-            if (left.value === 'parseInt' && p.length === 1) {
+            if (left.string === 'parseInt' && p.length === 1) {
                 warn('radix', left);
             }
             if (!option.evil) {
-                if (left.value === 'eval' || left.value === 'Function' ||
-                        left.value === 'execScript') {
+                if (left.string === 'eval' || left.string === 'Function' ||
+                        left.string === 'execScript') {
                     warn('evil', left);
-                } else if (p[0] && p[0].arity === 'string' &&
-                        (left.value === 'setTimeout' ||
-                        left.value === 'setInterval')) {
+                } else if (p[0] && p[0].id === '(string)' &&
+                        (left.string === 'setTimeout' ||
+                        left.string === 'setInterval')) {
                     warn('implied_evil', left);
                 }
             }
@@ -3948,11 +3825,10 @@ loop:   for (;;) {
         that.first = left;
         that.second = p;
         return that;
-    }, true);
+    }, '', true);
 
     prefix('(', function () {
         step_in('expression');
-        discard();
         no_space();
         edge();
         if (next_token.id === 'function') {
@@ -3962,7 +3838,6 @@ loop:   for (;;) {
         value.paren = true;
         no_space();
         step_out(')', this);
-        discard();
         if (value.id === 'function') {
             if (next_token.id === '(') {
                 warn('move_invocation');
@@ -3976,28 +3851,28 @@ loop:   for (;;) {
     infix('.', 170, function (left, that) {
         no_space(prev_token, token);
         no_space();
-        var name = identifier();
+        var name = identifier(), type;
         if (typeof name === 'string') {
             tally_property(name);
         }
         that.first = left;
         that.second = token;
-        if (left && left.value === 'arguments' &&
+        if (left && left.string === 'arguments' &&
                 (name === 'callee' || name === 'caller')) {
             warn('avoid_a', left, 'arguments.' + name);
-        } else if (!option.evil && left && left.value === 'document' &&
+        } else if (!option.evil && left && left.string === 'document' &&
                 (name === 'write' || name === 'writeln')) {
             warn('write_is_wrong', left);
         } else if (option.adsafe) {
-            if (!adsafe_top && left.value === 'ADSAFE') {
+            if (!adsafe_top && left.string === 'ADSAFE') {
                 if (name === 'id' || name === 'lib') {
-                    warn('adsafe', that);
+                    warn('adsafe_a', that);
                 } else if (name === 'go') {
                     if (xmode !== 'script') {
-                        warn('adsafe', that);
+                        warn('adsafe_a', that);
                     } else if (adsafe_went || next_token.id !== '(' ||
-                            peek(0).arity !== 'string' ||
-                            peek(0).value !== adsafe_id ||
+                            peek(0).id !== '(string)' ||
+                            peek(0).string !== adsafe_id ||
                             peek(1).id !== ',') {
                         stop('adsafe_a', that, 'go');
                     }
@@ -4014,18 +3889,12 @@ loop:   for (;;) {
                 if (banned[name] === true) {
                     warn('adsafe_a', token, name);
                 }
-                if (typeof predefined[left.value] !== 'boolean' ||
+                if (typeof predefined[left.string] !== 'boolean' ||    //// check for writeable
                         next_token.id === '(') {
                     break;
                 }
-                if (standard_property[name] === true) {
-                    if (next_token.id === '.') {
-                        warn('adsafe', that);
-                    }
-                    break;
-                }
                 if (next_token.id !== '.') {
-                    warn('adsafe', that);
+                    warn('adsafe_a', that);
                     break;
                 }
                 advance('.');
@@ -4038,47 +3907,61 @@ loop:   for (;;) {
                 }
             }
         }
+        type = property_type[name];
+        if (type && typeof type === 'string' && type !== '*') {
+            that.type = type;
+        }
         return that;
-    }, true);
+    }, '', true);
 
     infix('[', 170, function (left, that) {
+        var e, s;
         no_space_only(prev_token, token);
         no_space();
         step_in();
         edge();
-        var e = expression(0), s;
-        if (e.arity === 'number') {
-            if (left.id === 'arguments') {
+        e = expression(0);
+        switch (e.type) {
+        case 'number':
+            if (e.id === '(number)' && left.id === 'arguments') {
                 warn('use_param', left);
             }
-        } else if (e.arity === 'string') {
-            if (option.safe && (banned[e.value] ||
-                    e.value.charAt(0) === '_' || e.value.slice(-1) === '_')) {
-                warn('adsafe_subscript_a', e);
-            } else if (!option.evil &&
-                    (e.value === 'eval' || e.value === 'execScript')) {
-                warn('evil', e);
-            }
-            tally_property(e.value);
-            if (!option.sub && ix.test(e.value)) {
-                s = syntax[e.value];
-                if (!s || !s.reserved) {
-                    warn('subscript', e);
+            break;
+        case 'string':
+            if (e.id === '(string)') {
+                if (option.safe && (banned[e.string] ||
+                        e.string.charAt(0) === '_' || e.string.slice(-1) === '_')) {
+                    warn('adsafe_subscript_a', e);
+                } else if (!option.evil &&
+                        (e.string === 'eval' || e.string === 'execScript')) {
+                    warn('evil', e);
+                } else if (!option.sub && ix.test(e.string)) {
+                    s = syntax[e.string];
+                    if (!s || !s.reserved) {
+                        warn('subscript', e);
+                    }
                 }
+                tally_property(e.string);
+            } else if (option.safe && e.id !== 'typeof') {
+                warn('adsafe_subscript_a', e);
             }
-        } else if (option.safe) {
-            if (!((e.arity === 'prefix' && adsafe_prefix[e.id] === true) ||
-                    (e.arity === 'infix' && adsafe_infix[e.id] === true))) {
+            break;
+        case undefined:
+            if (option.safe) {
+                warn('adsafe_subscript_a', e);
+            }
+            break;
+        default:
+            if (option.safe) {
                 warn('adsafe_subscript_a', e);
             }
         }
         step_out(']', that);
-        discard();
         no_space(prev_token, token);
         that.first = left;
         that.second = e;
         return that;
-    }, true);
+    }, '', true);
 
     prefix('[', function () {
         this.arity = 'prefix';
@@ -4088,7 +3971,6 @@ loop:   for (;;) {
             while (next_token.id === ',') {
                 warn('unexpected_a', next_token);
                 advance(',');
-                discard();
             }
             if (next_token.id === ']') {
                 break;
@@ -4107,7 +3989,6 @@ loop:   for (;;) {
             }
         }
         step_out(']', this);
-        discard();
         return this;
     }, 170);
 
@@ -4115,8 +3996,8 @@ loop:   for (;;) {
     function property_name() {
         var id = optional_identifier(true);
         if (!id) {
-            if (next_token.arity === 'string') {
-                id = next_token.value;
+            if (next_token.id === '(string)') {
+                id = next_token.string;
                 if (option.safe) {
                     if (banned[id]) {
                         warn('adsafe_a');
@@ -4126,8 +4007,8 @@ loop:   for (;;) {
                     }
                 }
                 advance();
-            } else if (next_token.arity === 'number') {
-                id = next_token.value.toString();
+            } else if (next_token.id === '(number)') {
+                id = next_token.number.toString();
                 advance();
             }
         }
@@ -4139,64 +4020,150 @@ loop:   for (;;) {
         var id, paren = next_token, params = [];
         advance('(');
         step_in();
-        discard();
         no_space();
         if (next_token.id === ')') {
             no_space();
             step_out(')', paren);
-            discard();
             return;
         }
         for (;;) {
             edge();
             id = identifier();
             params.push(token);
-            add_label(id, option.unparam ? 'unparam' : 'parameter');
+            add_label(token, option.unparam ? 'parameter' : 'unparam');
             if (next_token.id === ',') {
                 comma();
             } else {
                 no_space();
                 step_out(')', paren);
-                discard();
                 return params;
             }
         }
     }
 
 
+    function complexity(exp) {
+        var score = 0;
+        if (exp) {
+            if (Array.isArray(exp)) {
+                exp.forEach(function (tok) {
+                    score += complexity(tok);
+                });
+            } else {
+                switch (exp.arity) {
+                case 'statement':
+                    switch (exp.id) {
+                    case 'if':
+                        score += complexity(exp.first) + complexity(exp.block) +
+                            complexity(exp['else']) + 1;
+                        break;
+                    case 'while':
+                    case 'do':
+                        if (exp.first.id !== 'true' && exp.first.number !== 1) {
+                            score += 1;
+                        }
+                        score += complexity(exp.first) + complexity(exp.block);
+                        break;
+                    case 'for':
+                        if (exp.second !== undefined &&
+                                exp.second.id !== 'true' &&
+                                exp.second.number !== 1) {
+                            score += 1;
+                        }
+                        score += complexity(exp.first) + complexity(exp.second) +
+                            complexity(exp.third) + complexity(exp.block);
+                        break;
+                    case 'switch':
+                        score += complexity(exp.first) +
+                            complexity(exp.second) + exp.second.length;
+                        if (exp.second[exp.second.length - 1].id === 'default') {
+                            score -= 1;
+                        }
+                        break;
+                    case 'try':
+                        if (exp.second) {
+                            score += 1;
+                        }
+                        if (exp.third) {
+                            score += 1;
+                        }
+                        score += complexity(exp.first) + complexity(exp.second) +
+                            complexity(exp.third) + complexity(exp.block);
+                        break;
+                    }
+                    break;
+                case 'prefix':
+                    score += complexity(exp.first);
+                    break;
+                case 'case':
+                case 'infix':
+                    score += complexity(exp.first) + complexity(exp.second);
+                    if (exp.id === '&&' || exp.id === '||') {
+                        score += 1;
+                    }
+                    break;
+                case 'ternary':
+                    score += complexity(exp.first) + complexity(exp.second) + complexity(exp.third);
+                    break;
+                }
+            }
+        }
+        return score;
+    }
+
+
     function do_function(func, name) {
-        var old_properties = properties,
+        var old_funct      = funct,
             old_option     = option,
-            old_global     = global,
             old_scope      = scope;
         funct = {
             '(name)'     : name || '\'' + (anonname || '').replace(nx, sanitize) + '\'',
             '(line)'     : next_token.line,
-            '(context)'  : funct,
+            '(context)'  : old_funct,
             '(breakage)' : 0,
             '(loopage)'  : 0,
             '(scope)'    : scope,
             '(token)'    : func
         };
-        properties  = old_properties && Object.create(old_properties);
-        option      = Object.create(old_option);
-        global      = Object.create(old_global);
-        scope       = Object.create(old_scope);
-        token.funct = funct;
+        option = Object.create(old_option);
+        scope = Object.create(old_scope);
         functions.push(funct);
+        func.name = name;
         if (name) {
-            add_label(name, 'function');
+            add_label(func, 'function', name);
         }
-        func.name = name || '';
+        func.writeable = false;
         func.first = funct['(params)'] = function_params();
         one_space();
         func.block = block(false);
-        funct      = funct['(context)'];
-        properties = old_properties;
+        if (funct['(old_property_type)']) {
+            property_type = funct['(old_property_type)'];
+            delete funct['(old_property_type)'];
+        }
+        funct['(complexity)'] = complexity(func.block) + 1;
+        if (option.confusion) {
+            funct['(confusion)'] = true;
+        }
+        funct      = old_funct;
         option     = old_option;
-        global     = old_global;
         scope      = old_scope;
     }
+
+
+    assignop('=');
+    assignop('+=', '+');
+    assignop('-=', '-');
+    assignop('*=', '*');
+    assignop('/=', '/').nud = function () {
+        stop('slash_equal');
+    };
+    assignop('%=', '%');
+    assignop('&=', '&');
+    assignop('|=', '|');
+    assignop('^=', '^');
+    assignop('<<=', '<<');
+    assignop('>>=', '>>');
+    assignop('>>>=', '>>>');
 
 
     prefix('{', function () {
@@ -4211,7 +4178,7 @@ loop:   for (;;) {
 // but requires that they be used in pairs.
 
             edge();
-            if (next_token.value === 'get' && peek().id !== ':') {
+            if (next_token.string === 'get' && peek().id !== ':') {
                 if (!option.es5) {
                     warn('es5');
                 }
@@ -4223,30 +4190,35 @@ loop:   for (;;) {
                 if (!i) {
                     stop('missing_property');
                 }
-                do_function(get, '');
+                get.string = '';
+                do_function(get);
                 if (funct['(loopage)']) {
                     warn('function_loop', get);
                 }
                 p = get.first;
                 if (p) {
-                    warn('parameter_a_get_b', p[0], p[0].value, i);
+                    warn('parameter_a_get_b', p[0], p[0].string, i);
                 }
                 comma();
                 set = next_token;
                 spaces();
                 edge();
                 advance('set');
+                set.string = '';
                 one_space_only();
                 j = property_name();
                 if (i !== j) {
-                    stop('expected_a_b', token, i, j || next_token.value);
+                    stop('expected_a_b', token, i, j || next_token.string);
                 }
-                do_function(set, '');
+                do_function(set);
+                if (set.block.length === 0) {
+                    warn('missing_a', token, 'throw');
+                }
                 p = set.first;
                 if (!p || p.length !== 1) {
                     stop('parameter_set_a', set, 'value');
-                } else if (p[0].value !== 'value') {
-                    stop('expected_a_b', p[0], 'value', p[0].value);
+                } else if (p[0].string !== 'value') {
+                    stop('expected_a_b', p[0], 'value', p[0].string);
                 }
                 name.first = [get, set];
             } else {
@@ -4256,7 +4228,6 @@ loop:   for (;;) {
                     stop('missing_property');
                 }
                 advance(':');
-                discard();
                 spaces();
                 name.first = expression(10);
             }
@@ -4281,18 +4252,15 @@ loop:   for (;;) {
             }
         }
         step_out('}', this);
-        discard();
         return this;
     });
 
     stmt('{', function () {
-        discard();
         warn('statement_block');
         this.arity = 'statement';
         this.block = statements();
         this.disrupt = this.block.disrupt;
         advance('}', this);
-        discard();
         return this;
     });
 
@@ -4314,10 +4282,10 @@ loop:   for (;;) {
 
         var assign, id, name;
 
-        if (funct['(onevar)'] && option.onevar) {
+        if (funct['(vars)'] && !option.vars) {
             warn('combine_var');
-        } else if (!funct['(global)']) {
-            funct['(onevar)'] = true;
+        } else if (funct !== global_funct) {
+            funct['(vars)'] = true;
         }
         this.arity = 'statement';
         this.first = [];
@@ -4325,10 +4293,7 @@ loop:   for (;;) {
         for (;;) {
             name = next_token;
             id = identifier();
-            if (funct['(global)'] && predefined[id] === false) {
-                warn('redefinition_a', token, id);
-            }
-            add_label(id, 'error');
+            add_label(name, 'becoming');
 
             if (next_token.id === '=') {
                 assign = next_token;
@@ -4348,7 +4313,9 @@ loop:   for (;;) {
             } else {
                 this.first.push(name);
             }
-            funct[id] = 'unused';
+            if (funct[id] === 'becoming') {
+                funct[id] = 'unused';
+            }
             if (next_token.id !== ',') {
                 break;
             }
@@ -4356,14 +4323,14 @@ loop:   for (;;) {
             indent.wrap = false;
             if (var_mode && next_token.line === token.line &&
                     this.first.length === 1) {
-                var_mode = false;
+                var_mode = null;
                 indent.open = false;
                 indent.at -= option.indent;
             }
             spaces();
             edge();
         }
-        var_mode = false;
+        var_mode = null;
         step_out();
         return this;
     });
@@ -4373,26 +4340,26 @@ loop:   for (;;) {
         if (in_block) {
             warn('function_block', token);
         }
-        var i = identifier();
-        if (i) {
-            add_label(i, 'unction');
-            no_space();
-        }
-        do_function(this, i, true);
+        var name = next_token, id = identifier();
+        add_label(name, 'unction');
+        no_space();
+        this.arity = 'statement';
+        do_function(this, id);
         if (next_token.id === '(' && next_token.line === token.line) {
             stop('function_statement');
         }
-        this.arity = 'statement';
         return this;
     });
 
     prefix('function', function () {
         one_space();
-        var i = optional_identifier();
-        if (i) {
+        var id = optional_identifier();
+        if (id) {
             no_space();
+        } else {
+            id = '';
         }
-        do_function(this, i);
+        do_function(this, id);
         if (funct['(loopage)']) {
             warn('function_loop');
         }
@@ -4405,23 +4372,21 @@ loop:   for (;;) {
         one_space();
         advance('(');
         step_in('control');
-        discard();
         no_space();
         edge();
         this.arity = 'statement';
         this.first = expected_condition(expected_relation(expression(0)));
         no_space();
         step_out(')', paren);
-        discard();
         one_space();
         this.block = block(true);
         if (next_token.id === 'else') {
             one_space();
             advance('else');
-            discard();
             one_space();
-            this['else'] = next_token.id === 'if' || next_token.id === 'switch' ?
-                statement(true) : block(true);
+            this['else'] = next_token.id === 'if' || next_token.id === 'switch'
+                ? statement(true)
+                : block(true);
             if (this['else'].disrupt && this.block.disrupt) {
                 this.disrupt = true;
             }
@@ -4446,40 +4411,35 @@ loop:   for (;;) {
         if (next_token.id === 'catch') {
             one_space();
             advance('catch');
-            discard();
             one_space();
             paren = next_token;
             advance('(');
             step_in('control');
-            discard();
             no_space();
             edge();
             old_scope = scope;
             scope = Object.create(old_scope);
-            exception_variable = next_token.value;
+            exception_variable = next_token.string;
             this.first = exception_variable;
             if (!next_token.identifier) {
                 warn('expected_identifier_a', next_token);
             } else {
-                add_label(exception_variable, 'exception');
+                add_label(next_token, 'exception');
             }
             advance();
             no_space();
             step_out(')', paren);
-            discard();
             one_space();
             this.second = block(false);
             scope = old_scope;
         }
         if (next_token.id === 'finally') {
-            discard();
             one_space();
             advance('finally');
-            discard();
             one_space();
             this.third = block(false);
         } else if (!this.second) {
-            stop('expected_a_b', next_token, 'catch', next_token.value);
+            stop('expected_a_b', next_token, 'catch', artifact());
         }
         return this;
     });
@@ -4491,7 +4451,6 @@ loop:   for (;;) {
         funct['(loopage)'] += 1;
         advance('(');
         step_in('control');
-        discard();
         no_space();
         edge();
         this.arity = 'statement';
@@ -4501,7 +4460,6 @@ loop:   for (;;) {
         }
         no_space();
         step_out(')', paren);
-        discard();
         one_space();
         this.block = block(true);
         if (this.block.disrupt) {
@@ -4516,53 +4474,63 @@ loop:   for (;;) {
 
     labeled_stmt('switch', function () {
 
-// switch.first             the switch expression
-// switch.second            the array of cases. A case is 'case' or 'default' token:
-//    case.first            the array of case expressions
-//    case.second           the array of statements
+// switch.first         the switch expression
+// switch.second        the array of cases. A case is 'case' or 'default' token:
+//    case.first        the array of case expressions
+//    case.second       the array of statements
 // If all of the arrays of statements are disrupt, then the switch is disrupt.
 
-        var particular,
+        var cases = [],
+            old_in_block = in_block,
+            particular,
             the_case = next_token,
             unbroken = true;
+
+        function find_duplicate_case(value) {
+            if (are_similar(particular, value)) {
+                warn('duplicate_a', value);
+            }
+        }
+
         funct['(breakage)'] += 1;
         one_space();
         advance('(');
-        discard();
         no_space();
         step_in();
         this.arity = 'statement';
         this.first = expected_condition(expected_relation(expression(0)));
         no_space();
         step_out(')', the_case);
-        discard();
         one_space();
         advance('{');
         step_in();
+        in_block = true;
         this.second = [];
         while (next_token.id === 'case') {
             the_case = next_token;
+            cases.forEach(find_duplicate_case);
             the_case.first = [];
+            the_case.arity = 'case';
             spaces();
             edge('case');
             advance('case');
             for (;;) {
                 one_space();
                 particular = expression(0);
+                cases.forEach(find_duplicate_case);
+                cases.push(particular);
                 the_case.first.push(particular);
                 if (particular.id === 'NaN') {
                     warn('unexpected_a', particular);
                 }
                 no_space_only();
                 advance(':');
-                discard();
                 if (next_token.id !== 'case') {
                     break;
                 }
                 spaces();
                 edge('case');
                 advance('case');
-                discard();
             }
             spaces();
             the_case.second = statements();
@@ -4586,12 +4554,11 @@ loop:   for (;;) {
         if (next_token.id === 'default') {
             spaces();
             the_case = next_token;
+            the_case.arity = 'case';
             edge('case');
             advance('default');
-            discard();
             no_space_only();
             advance(':');
-            discard();
             spaces();
             the_case.second = statements();
             if (the_case.second && the_case.second.length > 0) {
@@ -4605,6 +4572,7 @@ loop:   for (;;) {
         funct['(breakage)'] -= 1;
         spaces();
         step_out('}', this);
+        in_block = old_in_block;
         return this;
     });
 
@@ -4627,107 +4595,108 @@ loop:   for (;;) {
         }
         one_space();
         advance('while');
-        discard();
         var paren = next_token;
         one_space();
         advance('(');
         step_in();
-        discard();
         no_space();
         edge();
         this.first = expected_condition(expected_relation(expression(0)), bundle.unexpected_a);
         no_space();
         step_out(')', paren);
-        discard();
         funct['(breakage)'] -= 1;
         funct['(loopage)'] -= 1;
         return this;
     });
 
     labeled_stmt('for', function () {
-        var blok, filter, ok = false, paren = next_token, the_in, value;
+
+        var blok, filter, ok = false, paren = next_token, value;
         this.arity = 'statement';
         funct['(breakage)'] += 1;
         funct['(loopage)'] += 1;
         advance('(');
-        step_in('control');
-        discard();
-        spaces(this, paren);
-        no_space();
-        if (next_token.id === 'var') {
-            stop('move_var');
-        }
-        edge();
-        if (peek(0).id === 'in') {
-            value = next_token;
-            switch (funct[value.value]) {
-            case 'unused':
-                funct[value.value] = 'var';
-                break;
-            case 'closure':
-            case 'var':
-                break;
-            default:
-                warn('bad_in_a', value);
-            }
-            advance();
-            the_in = next_token;
-            advance('in');
-            the_in.first = value;
-            the_in.second = expression(20);
-            step_out(')', paren);
-            discard();
-            this.first = the_in;
+        if (next_token.id === ';') {
+            no_space();
+            advance(';');
+            no_space();
+            advance(';');
+            no_space();
+            advance(')');
             blok = block(true);
-            if (!option.forin) {
-                if (blok.length === 1 && typeof blok[0] === 'object' &&
-                        blok[0].value === 'if' && !blok[0]['else']) {
-                    filter = blok[0].first;
-                    while (filter.id === '&&') {
-                        filter = filter.first;
-                    }
-                    switch (filter.id) {
-                    case '===':
-                    case '!==':
-                        ok = filter.first.id === '[' ? (
-                            filter.first.first.value === the_in.second.value &&
-                            filter.first.second.value === the_in.first.value
-                        ) : (
-                            filter.first.id === 'typeof' &&
-                            filter.first.first.id === '[' &&
-                            filter.first.first.first.value === the_in.second.value &&
-                            filter.first.first.second.value === the_in.first.value
-                        );
-                        break;
-                    case '(':
-                        ok = filter.first.id === '.' && ((
-                            filter.first.first.value === the_in.second.value &&
-                            filter.first.second.value === 'hasOwnProperty' &&
-                            filter.second[0].value === the_in.first.value
-                        ) || (
-                            filter.first.first.value === 'ADSAFE' &&
-                            filter.first.second.value === 'has' &&
-                            filter.second[0].value === the_in.second.value &&
-                            filter.second[1].value === the_in.first.value
-                        ) || (
-                            filter.first.first.id === '.' &&
-                            filter.first.first.first.id === '.' &&
-                            filter.first.first.first.first.value === 'Object' &&
-                            filter.first.first.first.second.value === 'prototype' &&
-                            filter.first.first.second.value === 'hasOwnProperty' &&
-                            filter.first.second.value === 'call' &&
-                            filter.second[0].value === the_in.second.value &&
-                            filter.second[1].value === the_in.first.value
-                        ));
-                        break;
-                    }
-                }
-                if (!ok) {
-                    warn('for_if', this);
-                }
-            }
         } else {
-            if (next_token.id !== ';') {
+            step_in('control');
+            spaces(this, paren);
+            no_space();
+            if (next_token.id === 'var') {
+                stop('move_var');
+            }
+            edge();
+            if (peek(0).id === 'in') {
+                this.forin = true;
+                value = next_token;
+                switch (funct[value.string]) {
+                case 'unused':
+                    funct[value.string] = 'var';
+                    break;
+                case 'closure':
+                case 'var':
+                    break;
+                default:
+                    warn('bad_in_a', value);
+                }
+                advance();
+                advance('in');
+                this.first = value;
+                this.second = expression(20);
+                step_out(')', paren);
+                blok = block(true);
+                if (!option.forin) {
+                    if (blok.length === 1 && typeof blok[0] === 'object' &&
+                            blok[0].string === 'if' && !blok[0]['else']) {
+                        filter = blok[0].first;
+                        while (filter.id === '&&') {
+                            filter = filter.first;
+                        }
+                        switch (filter.id) {
+                        case '===':
+                        case '!==':
+                            ok = filter.first.id === '['
+                                ? filter.first.first.string === this.second.string &&
+                                    filter.first.second.string === this.first.string
+                                : filter.first.id === 'typeof' &&
+                                    filter.first.first.id === '[' &&
+                                    filter.first.first.first.string === this.second.string &&
+                                    filter.first.first.second.string === this.first.string;
+                            break;
+                        case '(':
+                            ok = filter.first.id === '.' && ((
+                                filter.first.first.string === this.second.string &&
+                                filter.first.second.string === 'hasOwnProperty' &&
+                                filter.second[0].string === this.first.string
+                            ) || (
+                                filter.first.first.string === 'ADSAFE' &&
+                                filter.first.second.string === 'has' &&
+                                filter.second[0].string === this.second.string &&
+                                filter.second[1].string === this.first.string
+                            ) || (
+                                filter.first.first.id === '.' &&
+                                filter.first.first.first.id === '.' &&
+                                filter.first.first.first.first.string === 'Object' &&
+                                filter.first.first.first.second.string === 'prototype' &&
+                                filter.first.first.second.string === 'hasOwnProperty' &&
+                                filter.first.second.string === 'call' &&
+                                filter.second[0].string === this.second.string &&
+                                filter.second[1].string === this.first.string
+                            ));
+                            break;
+                        }
+                    }
+                    if (!ok) {
+                        warn('for_if', this);
+                    }
+                }
+            } else {
                 edge();
                 this.first = [];
                 for (;;) {
@@ -4737,20 +4706,16 @@ loop:   for (;;) {
                     }
                     comma();
                 }
-            }
-            semicolon();
-            if (next_token.id !== ';') {
+                semicolon();
                 edge();
                 this.second = expected_relation(expression(0));
                 if (this.second.id !== 'true') {
                     expected_condition(this.second, bundle.unexpected_a);
                 }
-            }
-            semicolon(token);
-            if (next_token.id === ';') {
-                stop('expected_a_b', next_token, ')', ';');
-            }
-            if (next_token.id !== ')') {
+                semicolon(token);
+                if (next_token.id === ';') {
+                    stop('expected_a_b', next_token, ')', ';');
+                }
                 this.third = [];
                 edge();
                 for (;;) {
@@ -4760,12 +4725,11 @@ loop:   for (;;) {
                     }
                     comma();
                 }
+                no_space();
+                step_out(')', paren);
+                one_space();
+                blok = block(true);
             }
-            no_space();
-            step_out(')', paren);
-            discard();
-            one_space();
-            blok = block(true);
         }
         if (blok.disrupt) {
             warn('strange_loop', prev_token);
@@ -4777,7 +4741,7 @@ loop:   for (;;) {
     });
 
     disrupt_stmt('break', function () {
-        var label = next_token.value;
+        var label = next_token.string;
         this.arity = 'statement';
         if (funct['(breakage)'] === 0) {
             warn('unexpected_a', this);
@@ -4786,7 +4750,7 @@ loop:   for (;;) {
             one_space_only();
             if (funct[label] !== 'label') {
                 warn('not_a_label', next_token);
-            } else if (scope[label] !== funct) {
+            } else if (scope[label].funct !== funct) {
                 warn('not_a_scope', next_token);
             }
             this.first = next_token;
@@ -4799,7 +4763,7 @@ loop:   for (;;) {
         if (!option['continue']) {
             warn('unexpected_a', this);
         }
-        var label = next_token.value;
+        var label = next_token.string;
         this.arity = 'statement';
         if (funct['(breakage)'] === 0) {
             warn('unexpected_a', this);
@@ -4808,7 +4772,7 @@ loop:   for (;;) {
             one_space_only();
             if (funct[label] !== 'label') {
                 warn('not_a_label', next_token);
-            } else if (scope[label] !== funct) {
+            } else if (scope[label].funct !== funct) {
                 warn('not_a_scope', next_token);
             }
             this.first = next_token;
@@ -4818,6 +4782,9 @@ loop:   for (;;) {
     });
 
     disrupt_stmt('return', function () {
+        if (funct === global_funct) {
+            warn('unexpected_a', this);
+        }
         this.arity = 'statement';
         if (next_token.id !== ';' && next_token.line === token.line) {
             one_space_only();
@@ -4849,15 +4816,224 @@ loop:   for (;;) {
 
 // Harmony reserved words
 
-    reserve('let');
-    reserve('yield');
     reserve('implements');
     reserve('interface');
+    reserve('let');
     reserve('package');
     reserve('private');
     reserve('protected');
     reserve('public');
     reserve('static');
+    reserve('yield');
+
+
+// Type inference
+
+//     function get_type(one) {
+//         var type;
+//         if (typeof one === 'string') {
+//             return one;
+//         } else if (one.type) {
+//             return one.type;
+//         } else if (one.id === '.') {
+//             type = property_type[one.second.string];
+//             return typeof type === 'string' ? type : '';
+//         } else {
+//             return ((one.identifier && scope[one.string]) || one).type;
+//         }
+//     }
+
+
+//     function match_type(one_type, two_type, one, two) {
+//         if (one_type === two_type) {
+//             return true;
+//         } else {
+//             if (!funct.confusion && !two.warn) {
+//                 if (typeof one !== 'string') {
+//                     if (one.id === '.') {
+//                         one_type = '.' + one.second.string + ': ' + one_type;
+//                     } else {
+//                         one_type = one.string + ': ' + one_type;
+//                     }
+//                 }
+//                 if (two.id === '.') {
+//                     two_type = '.' + two.second.string + ': ' + one_type;
+//                 } else {
+//                     two_type = two.string + ': ' + one_type;
+//                 }
+//                 warn('type_confusion_a_b', two, one_type, two_type);
+//                 two.warn = true;
+//             }
+//             return false;
+//         }
+//     }
+
+
+//     function conform(one, two) {
+//
+// // The conform function takes a type string and a token, or two tokens.
+//
+//         var one_type = typeof one === 'string' ? one : one.type,
+//             two_type = two.type,
+//             two_thing;
+//
+// // If both tokens already have a type, and if they match, then we are done.
+// // Once a token has a type, it is locked. Neither token will change, but if
+// // they do not match, there will be a warning.
+//
+//         if (one_type) {
+//             if (two_type) {
+//                 match_type(one_type, two_type, one, two);
+//             } else {
+//
+// // two does not have a type, so look deeper. If two is a variable or property,
+// // then use its type if it has one, and make the deep type one's type if it
+// // doesn't. If the type was *, or if there was a mismatch, don't change the
+// // deep type.
+//
+//                 two_thing = two.id === '(identifier)'
+//                     ? scope[two.string]
+//                     : two.id === '.'
+//                     ? property_type[two.second.string]
+//                     : null;
+//                 if (two_thing) {
+//                     two_type = two_thing.type;
+//                     if (two_type) {
+//                         if (two_type !== '*') {
+//                             if (!match_type(one_type, two_type, one, two)) {
+//                                 return '';
+//                             }
+//                         }
+//                     } else {
+//                         two_thing.type = one_type;
+//                     }
+//                 }
+//
+// // In any case, we give two a type.
+//
+//                 two.type = one_type;
+//                 type_state_change = true;
+//                 return one_type;
+//             }
+//
+// // one does not have a type, but two does, so do the old switcheroo.
+//
+//         } else {
+//             if (two_type) {
+//                 return conform(two, one);
+//
+// // Neither token has a type yet. So we have to look deeper to see if either
+// // is a variable or property.
+//
+//             } else {
+//                 if (one.id === '(identifier)') {
+//                     one_type = scope[one.string].type;
+//                     if (one_type && one_type !== '*') {
+//                         one.type = one_type;
+//                         return conform(one, two);
+//                     }
+//                 } else if (one.id === '.') {
+//                     one_type = property_type[one.second.string];
+//                     if (one_type && one_type !== '*') {
+//                         one.type = scope[one.string].type;
+//                         return conform(one, two);
+//                     }
+//                 }
+//                 if (two.id === '(identifier)') {
+//                     two_type = scope[two.string].type;
+//                     if (two_type && two_type !== '*') {
+//                         two.type = two_type;
+//                         return conform(two, one);
+//                     }
+//                 } else if (two.id === '.') {
+//                     two_type = property_type[two.second.string];
+//                     if (two_type && two_type !== '*') {
+//                         two.type = scope[two.string].type;
+//                         return conform(two, one);
+//                     }
+//                 }
+//             }
+//         }
+//
+// // Return a falsy string if we were unable to determine the type of either token.
+//
+//         return '';
+//     }
+
+//     function conform_array(type, array) {
+//         array.forEach(function (item) {
+//             return conform(type, item);
+//         }, type);
+//     }
+
+
+//     function infer(node) {
+//         if (Array.isArray(node)) {
+//             node.forEach(infer);
+//         } else {
+//             switch (node.arity) {
+//             case 'statement':
+//                 infer_statement[node.id](node);
+//                 break;
+//             case 'infix':
+//                 infer(node.first);
+//                 infer(node.second);
+//                 switch (node.id) {
+//                 case '(':
+//                     conform('function', node.first);
+//                     break;
+//                 default:
+//                     stop('unfinished');
+//                 }
+//                 break;
+//             case 'number':
+//             case 'string':
+//             case 'boolean':
+//                 break;
+//             default:
+//                 stop('unfinished');
+//             }
+//         }
+//     }
+
+
+//     infer_statement = {
+//         'var': function (node) {
+//             var i, item, list = node.first;
+//             for (i = 0; i < list.length; i += 1) {
+//                 item = list[i];
+//                 if (item.id === '=') {
+//                     infer(item.second);
+//                     conform(item.first, item.second);
+//                     conform(item.first, item);
+//                 }
+//             }
+//         },
+//         'for': function (node) {
+//             infer(node.first);
+//             infer(node.second);
+//             if (node.forin) {
+//                 conform('string', node.first);
+//                 conform('object', node.second);
+//             } else {
+//                 infer(node.third);
+//                 conform_array('number', node.first);
+//                 conform('boolean', node.second);
+//                 conform_array('number', node.third);
+//             }
+//             infer(node.block);
+//         }
+//     };
+
+
+//     function infer_types(node) {
+//         do {
+//             funct = global_funct;
+//             scope = global_scope;
+//             type_state_change = false;
+//             infer(node);
+//         } while (type_state_change);
+//     }
 
 
 // Parse JSON
@@ -4871,17 +5047,17 @@ loop:   for (;;) {
                 while (next_token.id !== '(end)') {
                     while (next_token.id === ',') {
                         warn('unexpected_a', next_token);
-                        comma();
+                        advance(',');
                     }
-                    if (next_token.arity !== 'string') {
+                    if (next_token.id !== '(string)') {
                         warn('expected_string_a');
                     }
-                    if (object[next_token.value] === true) {
+                    if (object[next_token.string] === true) {
                         warn('duplicate_a');
-                    } else if (next_token.value === '__proto__') {
+                    } else if (next_token.string === '__proto__') {
                         warn('dangling_a');
                     } else {
-                        object[next_token.value] = true;
+                        object[next_token.string] = true;
                     }
                     advance();
                     advance(':');
@@ -4889,7 +5065,7 @@ loop:   for (;;) {
                     if (next_token.id !== ',') {
                         break;
                     }
-                    comma();
+                    advance(',');
                     if (next_token.id === '}') {
                         warn('unexpected_a', token);
                         break;
@@ -4906,13 +5082,13 @@ loop:   for (;;) {
                 while (next_token.id !== '(end)') {
                     while (next_token.id === ',') {
                         warn('unexpected_a', next_token);
-                        comma();
+                        advance(',');
                     }
                     json_value();
                     if (next_token.id !== ',') {
                         break;
                     }
-                    comma();
+                    advance(',');
                     if (next_token.id === ']') {
                         warn('unexpected_a', token);
                         break;
@@ -4962,7 +5138,7 @@ loop:   for (;;) {
             advance('-');
             no_space_only();
         }
-        if (next_token.arity === 'number') {
+        if (next_token.id === '(number)') {
             advance('(number)');
             return true;
         }
@@ -4970,7 +5146,7 @@ loop:   for (;;) {
 
 
     function css_string() {
-        if (next_token.arity === 'string') {
+        if (next_token.id === '(string)') {
             advance();
             return true;
         }
@@ -4979,7 +5155,7 @@ loop:   for (;;) {
     function css_color() {
         var i, number, paren, value;
         if (next_token.identifier) {
-            value = next_token.value;
+            value = next_token.string;
             if (value === 'rgb' || value === 'rgba') {
                 advance();
                 paren = next_token;
@@ -4988,8 +5164,8 @@ loop:   for (;;) {
                     if (i) {
                         comma();
                     }
-                    number = next_token.value;
-                    if (next_token.arity !== 'number' || number < 0) {
+                    number = next_token.number;
+                    if (next_token.id !== '(number)' || number < 0) {
                         warn('expected_positive_a', next_token);
                         advance();
                     } else {
@@ -5008,8 +5184,8 @@ loop:   for (;;) {
                 }
                 if (value === 'rgba') {
                     comma();
-                    number = +next_token.value;
-                    if (next_token.arity !== 'number' || number < 0 || number > 1) {
+                    number = next_token.number;
+                    if (next_token.id !== '(number)' || number < 0 || number > 1) {
                         warn('expected_fraction_a', next_token);
                     }
                     advance();
@@ -5020,7 +5196,7 @@ loop:   for (;;) {
                 }
                 advance(')', paren);
                 return true;
-            } else if (css_colorData[next_token.value] === true) {
+            } else if (css_colorData[next_token.string] === true) {
                 advance();
                 return true;
             }
@@ -5037,13 +5213,13 @@ loop:   for (;;) {
             advance('-');
             no_space_only();
         }
-        if (next_token.arity === 'number') {
+        if (next_token.id === '(number)') {
             advance();
-            if (next_token.arity !== 'string' &&
-                    css_lengthData[next_token.value] === true) {
+            if (next_token.id !== '(string)' &&
+                    css_lengthData[next_token.string] === true) {
                 no_space_only();
                 advance();
-            } else if (+token.value !== 0) {
+            } else if (+token.number !== 0) {
                 warn('expected_linear_a');
             }
             return true;
@@ -5057,10 +5233,10 @@ loop:   for (;;) {
             advance('-');
             no_space_only();
         }
-        if (next_token.arity === 'number') {
+        if (next_token.id === '(number)') {
             advance();
-            if (next_token.arity !== 'string' &&
-                    css_lengthData[next_token.value] === true) {
+            if (next_token.id !== '(string)' &&
+                    css_lengthData[next_token.string] === true) {
                 no_space_only();
                 advance();
             }
@@ -5072,7 +5248,7 @@ loop:   for (;;) {
 
     function css_width() {
         if (next_token.identifier) {
-            switch (next_token.value) {
+            switch (next_token.string) {
             case 'thin':
             case 'medium':
             case 'thick':
@@ -5087,7 +5263,7 @@ loop:   for (;;) {
 
     function css_margin() {
         if (next_token.identifier) {
-            if (next_token.value === 'auto') {
+            if (next_token.string === 'auto') {
                 advance();
                 return true;
             }
@@ -5097,7 +5273,7 @@ loop:   for (;;) {
     }
 
     function css_attr() {
-        if (next_token.identifier && next_token.value === 'attr') {
+        if (next_token.identifier && next_token.string === 'attr') {
             advance();
             advance('(');
             if (!next_token.identifier) {
@@ -5125,13 +5301,13 @@ loop:   for (;;) {
 
 
     function css_counter() {
-        if (next_token.identifier && next_token.value === 'counter') {
+        if (next_token.identifier && next_token.string === 'counter') {
             advance();
             advance('(');
             advance();
             if (next_token.id === ',') {
                 comma();
-                if (next_token.arity !== 'string') {
+                if (next_token.id !== '(string)') {
                     warn('expected_string_a');
                 }
                 advance();
@@ -5139,7 +5315,7 @@ loop:   for (;;) {
             advance(')');
             return true;
         }
-        if (next_token.identifier && next_token.value === 'counters') {
+        if (next_token.identifier && next_token.string === 'counters') {
             advance();
             advance('(');
             if (!next_token.identifier) {
@@ -5148,14 +5324,14 @@ loop:   for (;;) {
             advance();
             if (next_token.id === ',') {
                 comma();
-                if (next_token.arity !== 'string') {
+                if (next_token.id !== '(string)') {
                     warn('expected_string_a');
                 }
                 advance();
             }
             if (next_token.id === ',') {
                 comma();
-                if (next_token.arity !== 'string') {
+                if (next_token.id !== '(string)') {
                     warn('expected_string_a');
                 }
                 advance();
@@ -5167,9 +5343,14 @@ loop:   for (;;) {
     }
 
 
+    function css_radius() {
+        return css_length() && (next_token.id !== '(number)' || css_length());
+    }
+
+
     function css_shape() {
         var i;
-        if (next_token.identifier && next_token.value === 'rect') {
+        if (next_token.identifier && next_token.string === 'rect') {
             advance();
             advance('(');
             for (i = 0; i < 4; i += 1) {
@@ -5187,25 +5368,25 @@ loop:   for (;;) {
 
     function css_url() {
         var c, url;
-        if (next_token.identifier && next_token.value === 'url') {
+        if (next_token.identifier && next_token.string === 'url') {
             next_token = lex.range('(', ')');
-            url = next_token.value;
+            url = next_token.string;
             c = url.charAt(0);
             if (c === '"' || c === '\'') {
                 if (url.slice(-1) !== c) {
-                    warn('bad_url');
+                    warn('bad_url_a');
                 } else {
                     url = url.slice(1, -1);
                     if (url.indexOf(c) >= 0) {
-                        warn('bad_url');
+                        warn('bad_url_a');
                     }
                 }
             }
             if (!url) {
                 warn('missing_url');
             }
-            if (option.safe && ux.test(url)) {
-                stop('adsafe_a', next_token, url);
+            if (ux.test(url)) {
+                stop('bad_url_a');
             }
             urls.push(url);
             advance();
@@ -5218,7 +5399,7 @@ loop:   for (;;) {
     css_any = [css_url, function () {
         for (;;) {
             if (next_token.identifier) {
-                switch (next_token.value.toLowerCase()) {
+                switch (next_token.string.toLowerCase()) {
                 case 'url':
                     css_url();
                     break;
@@ -5238,6 +5419,39 @@ loop:   for (;;) {
             }
         }
     }];
+
+
+    function font_face() {
+        advance_identifier('font-family');
+        advance(':');
+        if (!css_name() && !css_string()) {
+            stop('expected_name_a');
+        }
+        semicolon();
+        advance_identifier('src');
+        advance(':');
+        while (true) {
+            if (next_token.string === 'local') {
+                advance_identifier('local');
+                advance('(');
+                if (ux.test(next_token.string)) {
+                    stop('bad_url_a');
+                }
+
+                if (!css_name() && !css_string()) {
+                    stop('expected_name_a');
+                }
+                advance(')');
+            } else if (!css_url()) {
+                stop('expected_a_b', next_token, 'url', artifact());
+            }
+            if (next_token.id !== ',') {
+                break;
+            }
+            comma();
+        }
+        semicolon();
+    }
 
 
     css_border_style = [
@@ -5286,6 +5500,8 @@ loop:   for (;;) {
             'border-bottom-width'
         ],
         'border-bottom-color': css_color,
+        'border-bottom-left-radius': css_radius,
+        'border-bottom-right-radius': css_radius,
         'border-bottom-style': css_border_style,
         'border-bottom-width': css_width,
         'border-collapse': ['collapse', 'separate'],
@@ -5296,6 +5512,29 @@ loop:   for (;;) {
         'border-left-color': css_color,
         'border-left-style': css_border_style,
         'border-left-width': css_width,
+        'border-radius': function () {
+            function count(separator) {
+                var n = 1;
+                if (separator) {
+                    advance(separator);
+                }
+                if (!css_length()) {
+                    return false;
+                }
+                while (next_token.id === '(number)') {
+                    if (!css_length()) {
+                        return false;
+                    }
+                    n += 1;
+                }
+                if (n > 4) {
+                    warn('bad_style');
+                }
+                return true;
+            }
+
+            return count() && (next_token.id !== '/' || count('/'));
+        },
         'border-right': [
             true, 'border-right-color', 'border-right-style',
             'border-right-width'
@@ -5309,6 +5548,8 @@ loop:   for (;;) {
             true, 'border-top-color', 'border-top-style', 'border-top-width'
         ],
         'border-top-color': css_color,
+        'border-top-left-radius': css_radius,
+        'border-top-right-radius': css_radius,
         'border-top-style': css_border_style,
         'border-top-width': css_width,
         'border-width': [4, css_width],
@@ -5440,7 +5681,7 @@ loop:   for (;;) {
     function style_attribute() {
         var v;
         while (next_token.id === '*' || next_token.id === '#' ||
-                next_token.value === '_') {
+                next_token.string === '_') {
             if (!option.css) {
                 warn('unexpected_a');
             }
@@ -5460,8 +5701,9 @@ loop:   for (;;) {
             if (!next_token.identifier) {
                 warn('expected_style_attribute');
             } else {
-                if (Object.prototype.hasOwnProperty.call(css_attribute_data, next_token.value)) {
-                    v = css_attribute_data[next_token.value];
+                if (Object.prototype.hasOwnProperty.call(css_attribute_data,
+                        next_token.string)) {
+                    v = css_attribute_data[next_token.string];
                 } else {
                     v = css_any;
                     if (!option.css) {
@@ -5476,6 +5718,9 @@ loop:   for (;;) {
 
 
     function style_value(v) {
+
+        /*jslint confusion: true */
+
         var i = 0,
             n,
             once,
@@ -5487,7 +5732,7 @@ loop:   for (;;) {
         case 'function':
             return v();
         case 'string':
-            if (next_token.identifier && next_token.value === v) {
+            if (next_token.identifier && next_token.string === v) {
                 advance();
                 return true;
             }
@@ -5499,7 +5744,7 @@ loop:   for (;;) {
             }
             vi = v[i];
             i += 1;
-            if (vi === true) {
+            if (typeof vi === 'boolean') {
                 break;
             } else if (typeof vi === 'number') {
                 n = vi;
@@ -5542,9 +5787,9 @@ loop:   for (;;) {
     }
 
     function style_child() {
-        if (next_token.arity === 'number') {
+        if (next_token.id === '(number)') {
             advance();
-            if (next_token.value === 'n' && next_token.identifier) {
+            if (next_token.string === 'n' && next_token.identifier) {
                 no_space_only();
                 advance();
                 if (next_token.id === '+') {
@@ -5557,7 +5802,7 @@ loop:   for (;;) {
             return;
         } else {
             if (next_token.identifier &&
-                    (next_token.value === 'odd' || next_token.value === 'even')) {
+                    (next_token.string === 'odd' || next_token.string === 'even')) {
                 advance();
                 return;
             }
@@ -5572,13 +5817,9 @@ loop:   for (;;) {
                     (xquote && next_token.id === xquote)) {
                 return;
             }
-            while (next_token.id === ';') {
-                warn('unexpected_a');
-                semicolon();
-            }
             v = style_attribute();
             advance(':');
-            if (next_token.identifier && next_token.value === 'inherit') {
+            if (next_token.identifier && next_token.string === 'inherit') {
                 advance();
             } else {
                 if (!style_value(v)) {
@@ -5589,15 +5830,15 @@ loop:   for (;;) {
             if (next_token.id === '!') {
                 advance('!');
                 no_space_only();
-                if (next_token.identifier && next_token.value === 'important') {
+                if (next_token.identifier && next_token.string === 'important') {
                     advance();
                 } else {
                     warn('expected_a_b',
-                        next_token, 'important', next_token.value);
+                        next_token, 'important', artifact());
                 }
             }
             if (next_token.id === '}' || next_token.id === xquote) {
-                warn('expected_a_b', next_token, ';', next_token.value);
+                warn('expected_a_b', next_token, ';', artifact());
             } else {
                 semicolon();
             }
@@ -5606,8 +5847,9 @@ loop:   for (;;) {
 
     function style_selector() {
         if (next_token.identifier) {
-            if (!Object.prototype.hasOwnProperty.call(html_tag, option.cap ?
-                    next_token.value.toLowerCase() : next_token.value)) {
+            if (!Object.prototype.hasOwnProperty.call(html_tag, option.cap
+                    ? next_token.string.toLowerCase()
+                    : next_token.string)) {
                 warn('expected_tagname_a');
             }
             advance();
@@ -5620,7 +5862,7 @@ loop:   for (;;) {
                 break;
             case ':':
                 advance(':');
-                switch (next_token.value) {
+                switch (next_token.string) {
                 case 'active':
                 case 'after':
                 case 'before':
@@ -5641,10 +5883,10 @@ loop:   for (;;) {
                 case 'root':
                 case 'target':
                 case 'visited':
-                    advance();
+                    advance_identifier(next_token.string);
                     break;
                 case 'lang':
-                    advance();
+                    advance_identifier('lang');
                     advance('(');
                     if (!next_token.identifier) {
                         warn('expected_lang_a');
@@ -5655,15 +5897,15 @@ loop:   for (;;) {
                 case 'nth-last-child':
                 case 'nth-last-of-type':
                 case 'nth-of-type':
-                    advance();
+                    advance_identifier(next_token.string);
                     advance('(');
                     style_child();
                     advance(')');
                     break;
                 case 'not':
-                    advance();
+                    advance_identifier('not');
                     advance('(');
-                    if (next_token.id === ':' && peek(0).value === 'not') {
+                    if (next_token.id === ':' && peek(0).string === 'not') {
                         warn('not');
                     }
                     style_selector();
@@ -5696,13 +5938,13 @@ loop:   for (;;) {
                     warn('expected_attribute_a');
                 }
                 advance();
-                if (next_token.id === '=' || next_token.value === '~=' ||
-                        next_token.value === '$=' ||
-                        next_token.value === '|=' ||
+                if (next_token.id === '=' || next_token.string === '~=' ||
+                        next_token.string === '$=' ||
+                        next_token.string === '|=' ||
                         next_token.id === '*=' ||
                         next_token.id === '^=') {
                     advance();
-                    if (next_token.arity !== 'string') {
+                    if (next_token.id !== '(string)') {
                         warn('expected_string_a');
                     }
                     advance();
@@ -5722,7 +5964,7 @@ loop:   for (;;) {
         for (;;) {
             style_selector();
             if (next_token.id === '</' || next_token.id === '{' ||
-                    next_token.id === '(end)') {
+                    next_token.id === '}' || next_token.id === '(end)') {
                 return '';
             }
             if (next_token.id === ',') {
@@ -5732,7 +5974,8 @@ loop:   for (;;) {
     }
 
     function style_list() {
-        while (next_token.id !== '</' && next_token.id !== '(end)') {
+        while (next_token.id !== '}' && next_token.id !== '</' &&
+                next_token.id !== '(end)') {
             style_pattern();
             xmode = 'styleproperty';
             if (next_token.id === ';') {
@@ -5751,38 +5994,40 @@ loop:   for (;;) {
         while (next_token.id === '@') {
             i = peek();
             advance('@');
-            if (next_token.identifier) {
-                switch (next_token.value) {
-                case 'import':
+            switch (next_token.string) {
+            case 'import':
+                advance_identifier('import');
+                if (!css_url()) {
+                    warn('expected_a_b',
+                        next_token, 'url', artifact());
                     advance();
-                    if (!css_url()) {
-                        warn('expected_a_b',
-                            next_token, 'url', next_token.value);
-                        advance();
-                    }
-                    semicolon();
-                    break;
-                case 'media':
-                    advance();
-                    for (;;) {
-                        if (!next_token.identifier || css_media[next_token.value] === true) {
-                            stop('expected_media_a');
-                        }
-                        advance();
-                        if (next_token.id !== ',') {
-                            break;
-                        }
-                        comma();
-                    }
-                    advance('{');
-                    style_list();
-                    advance('}');
-                    break;
-                default:
-                    warn('expected_at_a');
                 }
-            } else {
-                warn('expected_at_a');
+                semicolon();
+                break;
+            case 'media':
+                advance_identifier('media');
+                for (;;) {
+                    if (!next_token.identifier || css_media[next_token.string] !== true) {
+                        stop('expected_media_a');
+                    }
+                    advance();
+                    if (next_token.id !== ',') {
+                        break;
+                    }
+                    comma();
+                }
+                advance('{');
+                style_list();
+                advance('}');
+                break;
+            case 'font-face':
+                advance_identifier('font-face');
+                advance('{');
+                font_face();
+                advance('}');
+                break;
+            default:
+                stop('expected_at_a');
             }
         }
         style_list();
@@ -5812,7 +6057,6 @@ loop:   for (;;) {
             }
         }
         option.browser = true;
-        assume();
     }
 
     function do_attribute(a, v) {
@@ -5853,7 +6097,7 @@ loop:   for (;;) {
                 a === 'content' || a === 'data' ||
                 a.indexOf('src') >= 0 || a.indexOf('url') >= 0) {
             if (option.safe && ux.test(v)) {
-                stop('bad_url', next_token, v);
+                stop('bad_url_a', next_token, v);
             }
             urls.push(v);
         } else if (a === 'for') {
@@ -5882,7 +6126,9 @@ loop:   for (;;) {
             stop(
                 bundle.unrecognized_tag_a,
                 next_token,
-                name === name.toLowerCase() ? name : name + ' (capitalization error)'
+                name === name.toLowerCase()
+                    ? name
+                    : name + ' (capitalization error)'
             );
         }
         if (stack.length > 0) {
@@ -5940,13 +6186,13 @@ loop:   for (;;) {
                         stop('adsafe_script', token);
                     }
                     if (script.length !== 1 ||
-                            aint(script[0],             'id',    '(') ||
-                            aint(script[0].first,       'id',    '.') ||
-                            aint(script[0].first.first, 'value', 'ADSAFE') ||
-                            aint(script[0].second[0],   'value', adsafe_id)) {
+                            aint(script[0],             'id',     '(') ||
+                            aint(script[0].first,       'id',     '.') ||
+                            aint(script[0].first.first, 'string', 'ADSAFE') ||
+                            aint(script[0].second[0],   'string', adsafe_id)) {
                         stop('adsafe_id_go');
                     }
-                    switch (script[0].first.second.value) {
+                    switch (script[0].first.second.string) {
                     case 'id':
                         if (adsafe_may || adsafe_went ||
                                 script[0].second.length !== 1) {
@@ -5962,8 +6208,8 @@ loop:   for (;;) {
                                 aint(script[0].second[1], 'id', 'function') ||
                                 !script[0].second[1].first ||
                                 script[0].second[1].first.length !== 2 ||
-                                aint(script[0].second[1].first[0], 'value', 'dom') ||
-                                aint(script[0].second[1].first[1], 'value', 'lib')) {
+                                aint(script[0].second[1].first[0], 'string', 'dom') ||
+                                aint(script[0].second[1].first[1], 'string', 'lib')) {
                             stop('adsafe_go', next_token);
                         }
                         adsafe_went = true;
@@ -5976,10 +6222,7 @@ loop:   for (;;) {
             }
             xmode = 'html';
             advance('</');
-            if (!next_token.identifier && next_token.value !== 'script') {
-                warn('expected_a_b', next_token, 'script', next_token.value);
-            }
-            advance();
+            advance_identifier('script');
             xmode = 'outer';
             break;
         case 'style':
@@ -5988,26 +6231,21 @@ loop:   for (;;) {
             styles();
             xmode = 'html';
             advance('</');
-            if (!next_token.identifier && next_token.value !== 'style') {
-                warn('expected_a_b', next_token, 'style', next_token.value);
-            }
-            advance();
-            xmode = 'outer';
+            advance_identifier('style');
             break;
         case 'input':
             switch (attribute.type) {
-            case 'radio':
-            case 'checkbox':
             case 'button':
+            case 'checkbox':
+            case 'radio':
             case 'reset':
             case 'submit':
                 break;
-            case 'text':
-            case 'file':
-            case 'password':
             case 'file':
             case 'hidden':
             case 'image':
+            case 'password':
+            case 'text':
                 if (option.adsafe && attribute.autocomplete !== 'off') {
                     warn('adsafe_autocomplete');
                 }
@@ -6040,27 +6278,27 @@ loop:   for (;;) {
     }
 
     function html() {
+
+        /*jslint confusion: true */
+
         var attribute, attributes, is_empty, name, old_white = option.white,
             quote, tag_name, tag, wmode;
         xmode = 'html';
         xquote = '';
         stack = null;
         for (;;) {
-            switch (next_token.value) {
+            switch (next_token.string) {
             case '<':
                 xmode = 'html';
                 advance('<');
                 attributes = {};
                 tag_name = next_token;
-                if (!tag_name.identifier) {
-                    warn('bad_name_a', tag_name);
-                }
-                name = tag_name.value;
+                name = tag_name.string;
+                advance_identifier(name);
                 if (option.cap) {
                     name = name.toLowerCase();
                 }
                 tag_name.name = name;
-                advance();
                 if (!stack) {
                     stack = [];
                     do_begin(name);
@@ -6075,22 +6313,22 @@ loop:   for (;;) {
                     if (next_token.id === '/') {
                         advance('/');
                         if (next_token.id !== '>') {
-                            warn('expected_a_b', next_token, '>', next_token.value);
+                            warn('expected_a_b', next_token, '>', artifact());
                         }
                         break;
                     }
-                    if (next_token.id && next_token.id.substr(0, 1) === '>') {
+                    if (next_token.id && next_token.id.charAt(0) === '>') {
                         break;
                     }
                     if (!next_token.identifier) {
                         if (next_token.id === '(end)' || next_token.id === '(error)') {
-                            warn('expected_a_b', next_token, '>', next_token.value);
+                            warn('expected_a_b', next_token, '>', artifact());
                         }
                         warn('bad_name_a');
                     }
-                    option.white = true;
+                    option.white = false;
                     spaces();
-                    attribute = next_token.value;
+                    attribute = next_token.string;
                     option.white = old_white;
                     advance();
                     if (!option.cap && attribute !== attribute.toLowerCase()) {
@@ -6109,17 +6347,17 @@ loop:   for (;;) {
                         advance('=');
                         quote = next_token.id;
                         if (quote !== '"' && quote !== '\'') {
-                            stop('expected_a_b', next_token, '"', next_token.value);
+                            stop('expected_a_b', next_token, '"', artifact());
                         }
                         xquote = quote;
                         wmode = option.white;
-                        option.white = false;
+                        option.white = true;
                         advance(quote);
                         use_strict();
                         statements();
                         option.white = wmode;
                         if (next_token.id !== quote) {
-                            stop('expected_a_b', next_token, quote, next_token.value);
+                            stop('expected_a_b', next_token, quote, artifact());
                         }
                         xmode = 'html';
                         xquote = '';
@@ -6130,7 +6368,7 @@ loop:   for (;;) {
                         advance('=');
                         quote = next_token.id;
                         if (quote !== '"' && quote !== '\'') {
-                            stop('expected_a_b', next_token, '"', next_token.value);
+                            stop('expected_a_b', next_token, '"', artifact());
                         }
                         xmode = 'styleproperty';
                         xquote = quote;
@@ -6143,12 +6381,12 @@ loop:   for (;;) {
                     } else {
                         if (next_token.id === '=') {
                             advance('=');
-                            tag = next_token.value;
+                            tag = next_token.string;
                             if (!next_token.identifier &&
                                     next_token.id !== '"' &&
                                     next_token.id !== '\'' &&
-                                    next_token.arity !== 'string' &&
-                                    next_token.arity !== 'number' &&
+                                    next_token.id !== '(string)' &&
+                                    next_token.id !== '(string)' &&
                                     next_token.id !== '(color)') {
                                 warn('expected_attribute_value_a', token, attribute);
                             }
@@ -6173,7 +6411,7 @@ loop:   for (;;) {
                 if (!next_token.identifier) {
                     warn('bad_name_a');
                 }
-                name = next_token.value;
+                name = next_token.string;
                 if (option.cap) {
                     name = name.toLowerCase();
                 }
@@ -6190,7 +6428,7 @@ loop:   for (;;) {
                         next_token, closetag(tag_name.name), closetag(name));
                 }
                 if (next_token.id !== '>') {
-                    stop('expected_a_b', next_token, '>', next_token.value);
+                    stop('expected_a_b', next_token, '>', artifact());
                 }
                 xmode = 'outer';
                 advance('>');
@@ -6205,13 +6443,13 @@ loop:   for (;;) {
                     if (next_token.id === '>' || next_token.id === '(end)') {
                         break;
                     }
-                    if (next_token.value.indexOf('--') >= 0) {
+                    if (next_token.string.indexOf('--') >= 0) {
                         stop('unexpected_a', next_token, '--');
                     }
-                    if (next_token.value.indexOf('<') >= 0) {
+                    if (next_token.string.indexOf('<') >= 0) {
                         stop('unexpected_a', next_token, '<');
                     }
-                    if (next_token.value.indexOf('>') >= 0) {
+                    if (next_token.string.indexOf('>') >= 0) {
                         stop('unexpected_a', next_token, '>');
                     }
                 }
@@ -6223,7 +6461,7 @@ loop:   for (;;) {
             default:
                 if (next_token.id === '(end)') {
                     stop('missing_a', next_token,
-                        '</' + stack[stack.length - 1].value + '>');
+                        '</' + stack[stack.length - 1].string + '>');
                 } else {
                     advance();
                 }
@@ -6241,14 +6479,16 @@ loop:   for (;;) {
 
 // The actual JSLINT function itself.
 
-    var itself = function (the_source, the_option) {
-        var i, keys, predef, tree;
-        JSLINT.comments = [];
+    itself = function JSLint(the_source, the_option) {
+
+        var i, predef, tree;
         JSLINT.errors = [];
         JSLINT.tree = '';
-        begin = older_token = prev_token = token = next_token =
+        begin = prev_token = token = next_token =
             Object.create(syntax['(begin)']);
-        predefined = Object.create(standard);
+        predefined = {};
+        add_to_predefined(standard);
+        property_type = Object.create(standard_property_type);
         if (the_option) {
             option = Object.create(the_option);
             predef = option.predef;
@@ -6258,46 +6498,15 @@ loop:   for (;;) {
                         predefined[predef[i]] = true;
                     }
                 } else if (typeof predef === 'object') {
-                    keys = Object.keys(predef);
-                    for (i = 0; i < keys.length; i += 1) {
-                        predefined[keys[i]] = !!predef[keys];
-                    }
+                    add_to_predefined(predef);
                 }
             }
-            if (option.adsafe) {
-                option.safe = true;
-            }
-            if (option.safe) {
-                option.browser     =
-                    option['continue'] =
-                    option.css     =
-                    option.debug   =
-                    option.devel   =
-                    option.evil    =
-                    option.forin   =
-                    option.on      =
-                    option.rhino   =
-                    option.sub     =
-                    option.widget  =
-                    option.windows = false;
-
-                option.nomen       =
-                    option.strict  =
-                    option.undef   = true;
-
-                predefined.Date         =
-                    predefined['eval']  =
-                    predefined.Function =
-                    predefined.Object   = null;
-
-                predefined.ADSAFE  =
-                    predefined.lib = false;
-            }
+            do_safe();
         } else {
             option = {};
         }
-        option.indent = +option.indent || 0;
-        option.maxerr = option.maxerr || 50;
+        option.indent = +option.indent || 4;
+        option.maxerr = +option.maxerr || 50;
         adsafe_id = '';
         adsafe_may = adsafe_top = adsafe_went = false;
         approved = {};
@@ -6312,11 +6521,8 @@ loop:   for (;;) {
         for (i = 0; i < option.indent; i += 1) {
             tab += ' ';
         }
-        global = Object.create(predefined);
-        scope = global;
-        funct = {
-            '(global)': true,
-            '(name)': '(global)',
+        global_scope = scope = {};
+        global_funct = funct = {
             '(scope)': scope,
             '(breakage)': 0,
             '(loopage)': 0
@@ -6325,30 +6531,29 @@ loop:   for (;;) {
 
         comments_off = false;
         ids = {};
-        implied = {};
         in_block = false;
-        indent = false;
+        indent = null;
         json_mode = false;
         lookahead = [];
         member = {};
-        properties = null;
+        node_js = false;
         prereg = true;
         src = false;
         stack = null;
         strict_mode = false;
         urls = [];
-        var_mode = false;
+        var_mode = null;
         warnings = 0;
-        xmode = false;
+        xmode = '';
         lex.init(the_source);
 
         assume();
 
         try {
             advance();
-            if (next_token.arity === 'number') {
+            if (next_token.id === '(number)') {
                 stop('unexpected_a');
-            } else if (next_token.value.charAt(0) === '<') {
+            } else if (next_token.string.charAt(0) === '<') {
                 html();
                 if (option.adsafe && !adsafe_went) {
                     warn('adsafe_go', this);
@@ -6368,13 +6573,13 @@ loop:   for (;;) {
                     xmode = 'style';
                     advance();
                     if (token.id !== '@' || !next_token.identifier ||
-                            next_token.value !== 'charset' || token.line !== 1 ||
+                            next_token.string !== 'charset' || token.line !== 1 ||
                             token.from !== 1) {
                         stop('css');
                     }
                     advance();
-                    if (next_token.arity !== 'string' &&
-                            next_token.value !== 'UTF-8') {
+                    if (next_token.id !== '(string)' &&
+                            next_token.string !== 'UTF-8') {
                         stop('css');
                     }
                     advance();
@@ -6385,32 +6590,29 @@ loop:   for (;;) {
                 default:
                     if (option.adsafe && option.fragment) {
                         stop('expected_a_b',
-                            next_token, '<div>', next_token.value);
+                            next_token, '<div>', artifact());
                     }
 
-// If the first token is predef semicolon, ignore it. This is sometimes used when
-// files are intended to be appended to files that may be sloppy. predef sloppy
+// If the first token is a semicolon, ignore it. This is sometimes used when
+// files are intended to be appended to files that may be sloppy. A sloppy
 // file may be depending on semicolon insertion on its last line.
 
                     step_in(1);
-                    if (next_token.id === ';') {
+                    if (next_token.id === ';' && !node_js) {
                         semicolon();
-                    }
-                    if (next_token.value === 'use strict') {
-                        warn('function_strict');
-                        use_strict();
                     }
                     adsafe_top = true;
                     tree = statements();
                     begin.first = tree;
                     JSLINT.tree = begin;
+                    // infer_types(tree);
                     if (option.adsafe && (tree.length !== 1 ||
                             aint(tree[0], 'id', '(') ||
                             aint(tree[0].first, 'id', '.') ||
-                            aint(tree[0].first.first, 'value', 'ADSAFE') ||
-                            aint(tree[0].first.second, 'value', 'lib') ||
+                            aint(tree[0].first.first, 'string', 'ADSAFE') ||
+                            aint(tree[0].first.second, 'string', 'lib') ||
                             tree[0].second.length !== 2 ||
-                            tree[0].second[0].arity !== 'string' ||
+                            tree[0].second[0].id !== '(string)' ||
                             aint(tree[0].second[1], 'id', 'function'))) {
                         stop('adsafe_lib');
                     }
@@ -6441,12 +6643,12 @@ loop:   for (;;) {
             function_data,
             globals,
             i,
-            implieds = [],
             j,
             kind,
             members = [],
             name,
             the_function,
+            undef = [],
             unused = [];
         if (itself.errors.length) {
             data.errors = itself.errors;
@@ -6456,24 +6658,12 @@ loop:   for (;;) {
             data.json = true;
         }
 
-        for (name in implied) {
-            if (Object.prototype.hasOwnProperty.call(implied, name)) {
-                implieds.push({
-                    name: name,
-                    line: implied[name]
-                });
-            }
-        }
-        if (implieds.length > 0) {
-            data.implieds = implieds;
-        }
-
         if (urls.length > 0) {
             data.urls = urls;
         }
 
-        globals = Object.keys(functions[0]).filter(function (value) {
-            return value.charAt(0) !== '(' ? value : undefined;
+        globals = Object.keys(global_scope).filter(function (value) {
+            return value.charAt(0) !== '(' && typeof standard[value] !== 'boolean';
         });
         if (globals.length > 0) {
             data.globals = globals;
@@ -6491,13 +6681,17 @@ loop:   for (;;) {
                         kind = the_function[name];
                         if (kind === 'unction' || kind === 'unparam') {
                             kind = 'unused';
-                        } else if (typeof kind === 'boolean') {
-                            kind = 'global';
                         }
                         if (Array.isArray(function_data[kind])) {
                             function_data[kind].push(name);
                             if (kind === 'unused') {
                                 unused.push({
+                                    name: name,
+                                    line: the_function['(line)'],
+                                    'function': the_function['(name)']
+                                });
+                            } else if (kind === 'undef') {
+                                undef.push({
                                     name: name,
                                     line: the_function['(line)'],
                                     'function': the_function['(name)']
@@ -6513,13 +6707,17 @@ loop:   for (;;) {
                 }
             }
             function_data.name = the_function['(name)'];
-            function_data.param = the_function['(params)'];
+            function_data.params = the_function['(params)'];
             function_data.line = the_function['(line)'];
+            function_data['(complexity)'] = the_function['(complexity)'];
             data.functions.push(function_data);
         }
 
         if (unused.length > 0) {
             data.unused = unused;
+        }
+        if (undef.length > 0) {
+            data['undefined'] = undef;
         }
 
         members = [];
@@ -6535,28 +6733,28 @@ loop:   for (;;) {
 
 
     itself.report = function (errors_only) {
-        var data = itself.data();
+        var data = itself.data(), err, evidence, i, italics, j, key, keys, length,
+            mem = '', name, names, output = [], snippets, the_function, type,
+            warning;
 
-        var err, evidence, i, j, key, keys, length, mem = '', name, names,
-            output = [], snippets, the_function, warning;
-
-        function detail(h, array) {
-            var comma_needed, i, singularity;
-            if (array) {
+        function detail(h, value) {
+            var comma_needed, singularity;
+            if (Array.isArray(value)) {
                 output.push('<div><i>' + h + '</i> ');
-                array = array.sort();
-                for (i = 0; i < array.length; i += 1) {
-                    if (array[i] !== singularity) {
-                        singularity = array[i];
+                value.sort().forEach(function (item) {
+                    if (item !== singularity) {
+                        singularity = item;
                         output.push((comma_needed ? ', ' : '') + singularity);
                         comma_needed = true;
                     }
-                }
+                });
                 output.push('</div>');
+            } else if (value) {
+                output.push('<div><i>' + h + '</i> ' + value + '</div>');
             }
         }
 
-        if (data.errors || data.implieds || data.unused) {
+        if (data.errors || data.unused || data['undefined']) {
             err = true;
             output.push('<div id=errors><i>Error:</i>');
             if (data.errors) {
@@ -6564,30 +6762,33 @@ loop:   for (;;) {
                     warning = data.errors[i];
                     if (warning) {
                         evidence = warning.evidence || '';
-                        output.push('<p>Problem' + (isFinite(warning.line) ? ' at line ' +
-                            warning.line + ' character ' + warning.character : '') +
+                        output.push('<p>Problem' + (isFinite(warning.line)
+                            ? ' at line ' + String(warning.line) +
+                                ' character ' + String(warning.character)
+                            : '') +
                             ': ' + warning.reason.entityify() +
                             '</p><p class=evidence>' +
-                            (evidence && (evidence.length > 80 ? evidence.slice(0, 77) + '...' :
-                            evidence).entityify()) + '</p>');
+                            (evidence && (evidence.length > 80
+                                ? evidence.slice(0, 77) + '...'
+                                : evidence).entityify()) + '</p>');
                     }
                 }
             }
 
-            if (data.implieds) {
+            if (data['undefined']) {
                 snippets = [];
-                for (i = 0; i < data.implieds.length; i += 1) {
-                    snippets[i] = '<code>' + data.implieds[i].name + '</code>&nbsp;<i>' +
-                        data.implieds[i].line + '</i>';
+                for (i = 0; i < data['undefined'].length; i += 1) {
+                    snippets[i] = '<code><u>' + data['undefined'][i].name + '</u></code>&nbsp;<i>' +
+                        String(data['undefined'][i].line) + ' </i> <small>' +
+                        data['undefined'][i]['function'] + '</small>';
                 }
-                output.push('<p><i>Implied global:</i> ' + snippets.join(', ') + '</p>');
+                output.push('<p><i>Undefined variable:</i> ' + snippets.join(', ') + '</p>');
             }
-
             if (data.unused) {
                 snippets = [];
                 for (i = 0; i < data.unused.length; i += 1) {
                     snippets[i] = '<code><u>' + data.unused[i].name + '</u></code>&nbsp;<i>' +
-                        data.unused[i].line + ' </i> <small>' +
+                        String(data.unused[i].line) + ' </i> <small>' +
                         data.unused[i]['function'] + '</small>';
                 }
                 output.push('<p><i>Unused variable:</i> ' + snippets.join(', ') + '</p>');
@@ -6620,14 +6821,16 @@ loop:   for (;;) {
             for (i = 0; i < data.functions.length; i += 1) {
                 the_function = data.functions[i];
                 names = [];
-                if (the_function.param) {
-                    for (j = 0; j < the_function.param.length; j += 1) {
-                        names[j] = the_function.param[j].value;
+                if (the_function.params) {
+                    for (j = 0; j < the_function.params.length; j += 1) {
+                        names[j] = the_function.params[j].string;
                     }
                 }
-                output.push('<br><div class=function><i>' + the_function.line +
-                    '</i> ' + the_function.name.entityify() +
+                output.push('<br><div class=function><i>' +
+                    String(the_function.line) + '</i> ' +
+                    the_function.name.entityify() +
                     '(' + names.join(', ') + ')</div>');
+                detail('<big><b>Undefined</b></big>', the_function['undefined']);
                 detail('<big><b>Unused</b></big>', the_function.unused);
                 detail('Closure', the_function.closure);
                 detail('Variable', the_function['var']);
@@ -6635,31 +6838,73 @@ loop:   for (;;) {
                 detail('Outer', the_function.outer);
                 detail('Global', the_function.global);
                 detail('Label', the_function.label);
+                detail('Complexity', the_function['(complexity)']);
             }
 
             if (data.member) {
                 keys = Object.keys(data.member);
                 if (keys.length) {
                     keys = keys.sort();
-                    mem = '<br><pre id=properties>/*properties ';
-                    length = 13;
-                    for (i = 0; i < keys.length; i += 1) {
-                        key = keys[i];
-                        name = ix.test(key) ? key :
-                            '\'' + key.entityify().replace(nx, sanitize) + '\'';
-                        if (length + name.length > 72) {
-                            output.push(mem + '<br>');
-                            mem = '    ';
-                            length = 1;
+                    output.push('<br><pre id=properties>/*properties<br>');
+                    mem = '    ';
+                    italics = 0;
+                    j = 0;
+                    if (option.confusion) {
+                        for (i = 0; i < keys.length; i += 1) {
+                            key = keys[i];
+                            if (typeof standard_property_type[key] !== 'string') {
+                                name = ix.test(key)
+                                    ? key
+                                    : '\'' + key.entityify().replace(nx, sanitize) + '\'';
+                                if (data.member[key] === 1) {
+                                    name = '<i>' + name + '</i>';
+                                    italics += 1;
+                                    j = 1;
+                                }
+                                if (i < keys.length - 1) {
+                                    name += ', ';
+                                }
+                                if (mem.length + name.length - (italics * 7) > 80) {
+                                    output.push(mem + '<br>');
+                                    mem = '    ';
+                                    italics = j;
+                                }
+                                mem += name;
+                                j = 0;
+                            }
                         }
-                        length += name.length + 2;
-                        if (data.member[key] === 1) {
-                            name = '<i>' + name + '</i>';
+                    } else {
+                        for (i = 0; i < keys.length; i += 1) {
+                            key = keys[i];
+                            type = property_type[key];
+                            if (typeof type !== 'string') {
+                                type = '';
+                            }
+                            if (standard_property_type[key] !== type) {
+                                name = ix.test(key)
+                                    ? key
+                                    : '\'' + key.entityify().replace(nx, sanitize) + '\'';
+                                length += name.length + 2;
+                                if (data.member[key] === 1) {
+                                    name = '<i>' + name + '</i>';
+                                    italics += 1;
+                                    j = 1;
+                                }
+                                if (type) {
+                                    name += ': ' + type;
+                                }
+                                if (i < keys.length - 1) {
+                                    name += ', ';
+                                }
+                                if (mem.length + name.length - (italics * 7) > 80) {
+                                    output.push(mem + '<br>');
+                                    mem = '    ';
+                                    italics = j;
+                                }
+                                mem += name;
+                                j = 0;
+                            }
                         }
-                        if (i < keys.length - 1) {
-                            name += ', ';
-                        }
-                        mem += name;
                     }
                     output.push(mem + '<br>*/</pre>');
                 }
@@ -6670,7 +6915,7 @@ loop:   for (;;) {
     };
     itself.jslint = itself;
 
-    itself.edition = '2011-05-10';
+    itself.edition = '2011-11-02';
 
     return itself;
 


### PR DESCRIPTION
Updated jslint to version as of 2011-11-03. This update fixes the 'Redefinition' and 'Read only' errors with the "util" module that appeared since running on node v0.6.x amongst other things.
