### PR TITLE
Add --sloppy option to the executable

### DIFF
--- a/bin/jslint.js
+++ b/bin/jslint.js
@@ -13,7 +13,7 @@ function commandOptions() {
             'newcap', 'node', 'nomen', 'on', 'onevar', 'passfail',
             'plusplus', 'regexp', 'rhino', 'undef', 'safe', 'windows',
             'strict', 'sub', 'white', 'widget', 'goodparts', 'json',
-            'color'
+            'color', 'sloppy'
         ],
         commandOpts = {
             'indent' : Number,


### PR DESCRIPTION
This allows the user to pass --sloppy to lib/jslint.js which tells it to omit the "use strict" warnings

The motivation for this is to make it more usable with syntastic(http://github.com/scrooloose/syntastic). Currently, we constantly get "use strict" warnings, which is makes it unsuitable for just doing basic automated syntax checks.
