### PR TITLE
Fix UTF-8 BOM in linter

### DIFF
--- a/bin/jslint.js
+++ b/bin/jslint.js
@@ -68,17 +68,11 @@ var maybeExit = (function () {
 
 function lintFile(file) {
     'use strict';
-    fs.readFile(file, function (err, data) {
+    fs.readFile(file, 'utf8', function (err, data) {
         if (err) {
             throw err;
         }
 
-        // Fix UTF8 with BOM
-        if (0xEF === data[0] && 0xBB === data[1] && 0xBF === data[2]) {
-            data = data.slice(3);
-        }
-
-        data = data.toString("utf8");
         var lint = linter.lint(data, parsed);
 
         if (parsed.json) {

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -12,6 +12,12 @@ function addDefaults(options) {
 
 exports.lint = function (script, options) {
     'use strict';
+
+    // Fix UTF8 with BOM
+    if (script.charCodeAt(0) === 0xFEFF) {
+        script = script.slice(1);
+    }
+
     // remove shebang
     /*jslint regexp: true*/
     script = script.replace(/^\#\!.*/, "");


### PR DESCRIPTION
It's more logical to clear BOM in linter.js.

I've done it same way as node.js does it for module files: https://github.com/joyent/node/blob/master/lib/module.js#L454
