### PR TITLE
Restructured README.md, added command line array example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Easily use [JSLint][] from the command line.
 
     jslint app.js
 
+
 ## Install
 
     npm install jslint

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -20,11 +20,6 @@ exports.lint = function (script, options) {
     delete options.argv;
     options = addDefaults(options);
 
-    if (options.predef && !Array.isArray(options.predef)) {
-        options.predef = options.predef.split(',')
-            .filter(function (n) { return !!n; });
-    }
-
     var ok = JSLINT(script, options),
         result = {
             ok: true,


### PR DESCRIPTION
Passing arrays (as for --predef) was not so clear, added example.

Restructured the command line examples to make it clearer on a glance what command does what.
