### PR TITLE
Made nodelint.js the "main" script

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "bin": {
         "jslint": "./bin/jslint.js"
     },
-    "main": "./lib/jslint.js",
+    "main": "./lib/nodelint.js",
     "dependencies": {
         "nopt": "~1.0.0"
     },


### PR DESCRIPTION
It seems wrong for the jslint.js to be the main script for this package. nodejslint.js is the wrapper around jslint that allows you to run jslint via node. This change allows a node app to require('jslint') and get back a callable jslint library (#38).
