### PR TITLE
In Quantal the nodejs script name has changed

### DIFF
--- a/bin/jslint.js
+++ b/bin/jslint.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env nodejs
 
 var linter = require("../lib/linter");
 var reporter = require("../lib/reporter");


### PR DESCRIPTION
In Quantal (Ubuntu 12.10) the nodejs package no longer installs
a script called "node", the new script name is "nodejs".
