### PR TITLE
Wait for stdout to drain before exiting.

### DIFF
--- a/bin/jslint.js
+++ b/bin/jslint.js
@@ -60,7 +60,9 @@ var maybeExit = (function () {
 
         if (filesLeft === 0) {
             // This was the last file.
-            process.exit(ok ? 0 : 1);
+            process.stdout.on('drain', function () {
+                process.exit(ok ? 0 : 1);
+            });
         }
     };
 }());


### PR DESCRIPTION
If stdout is not flushed when process.exit() is called, buffered output will may reach the tty. 

Problem was observed when running on Cygwin on Windows 7.
