### PR TITLE
Updated README to show global installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Easily use [JSLint][] from the command line.
 
 ## Install
 
-    npm install jslint
+    npm install jslint -g
 
 ## Self-Lint
 


### PR DESCRIPTION
I had to use 

<pre>
sudo npm install jslint -g
</pre>


to be able to use jslint from command line. So I added the "-g" option to the README
