### PR TITLE
Made terse mode emacs-friendly

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -22,7 +22,7 @@ exports.report = function (file, lint, colorize, terse) {
             for (i = 0; i < len; i += 1) {
                 e = lint.errors[i];
                 if (e) {
-                    log(file + '(' + e.line + '):' + e.reason);
+                    log(file + ':' + e.line + ':' + e.character + ': ' + e.reason);
                 }
             }
         } else {


### PR DESCRIPTION
With this format, emacs (and probably other tools) is able to automatically link to the corresponding position in the file.
