### PR TITLE
README Usage examples: Referenced real files in the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,23 +16,23 @@ Easily use [JSLint][] from the command line.
 
 Multiple files
 
-    jslint lib/worker.js lib/server.js
+    jslint lib/color.js lib/reporter.js
 
 All JSLint options supported
 
-    jslint --white --vars --regexp app.js
+    jslint --white --vars --regexp lib/color.js
 
 Defaults to true, but you can specify false
 
-    jslint --bitwise false app.js
+    jslint --bitwise false lib/color.js
 
 Pass arrays
 
-	jslint --predef $ --predef Backbone app.js
+    jslint --predef $ --predef Backbone lib/color.js
 
 JSLint your entire project
 
-	find . -name "*.js" -print0 | xargs -0 jslint
+    find . -name "*.js" -print0 | xargs -0 jslint
 
 
 ## License


### PR DESCRIPTION
If users run the README example commands within `node-jslint/`, they'll be more likely to work out of the box.
