### PR TITLE
Don't incorrectly warn about redefining variables.

### DIFF
--- a/lib/jslint.js
+++ b/lib/jslint.js
@@ -1945,7 +1945,9 @@ klass:              do {
                     }
                     kind = 'var';
                 } else {
-                    warn('already_defined', token, name);
+                    if (!predefined[name]) {
+                        warn('already_defined', token, name);
+                    }
                 }
             } else {
 


### PR DESCRIPTION
Globals declared with the global declaration take an optional parameter to allow them to be redefined.  Respect the parameter.
For example /*global myVar: true */ should not warn about myVar being used before it is defined, nor should it warn if myVar is being redefined (perhaps as a function).  This allows functions to be declared after they are used without warnings.
