### PR TITLE
Only wait for drain event on stdout when stdout would be in non-blocking...

### DIFF
--- a/bin/jslint.js
+++ b/bin/jslint.js
@@ -61,9 +61,15 @@ var maybeExit = (function () {
 
         if (filesLeft === 0) {
             // This was the last file.
-            process.stdout.on('drain', function () {
+
+            if (process.stdout.isTTY) {
                 process.exit(ok ? 0 : 1);
-            });
+
+            } else {
+                process.stdout.on('drain', function () {
+                    process.exit(ok ? 0 : 1);
+                });
+            }
         }
     };
 }());


### PR DESCRIPTION
Bug fix for issue https://github.com/reid/node-jslint/issues/68 that I created. It checks if stdout is a terminal before waiting on the drain event - if it's not, then it just exits directly.
