### PR TITLE
Fix working directory jslintrc

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -9,6 +9,15 @@ function loadAndParseConfig(filePath) {
             JSON.parse(fs.readFileSync(filePath, "utf-8")) : {};
 }
 
+function isEmpty( o ) {
+    'use strict';
+    var p;
+    for (p in o ) {
+        if ( o.hasOwnProperty( p ) ) { return false; }
+    }
+    return true;
+}
+
 function merge(source, add) {
     'use strict';
 
@@ -30,10 +39,14 @@ exports.merge = merge;
 function mergeConfigs(homerc) {
     'use strict';
     var homeConfig = loadAndParseConfig(homerc),
-        args = [].concat(arguments),
+        args = Array.prototype.slice.call(arguments),
         cwdrcs = args.slice(1),
-        cwdConfig = loadAndParseConfig(cwdrcs[0]) || loadAndParseConfig(cwdrcs[1]),
+        cwdConfig = loadAndParseConfig(cwdrcs[0]),
         config;
+
+        if (isEmpty(cwdConfig)) {
+            cwdConfig = loadAndParseConfig(cwdrcs[1]);
+        }
 
 
     config = merge(cwdConfig, homeConfig);


### PR DESCRIPTION
- [].concat(arguments) was returning an empty array

cwdConfig = loadAndParseConfig(cwdrcs[0]) || loadAndParseConfig(cwdrcs[1])

loadAndParseConfig() is returning empty object and not false/null so it not using the .jslintrc even if there is no jslintrc
