### PR TITLE
Glob support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Pass arrays
 
 JSLint your entire project
 
-    find . -name "*.js" -print0 | xargs -0 jslint
+    jslint '**/*.js'
 
 Using JSLint with a config file
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -2,6 +2,7 @@ var linter = require("./linter");
 var reporter = require("./reporter");
 var nopt = require("nopt");
 var fs = require("fs");
+var glob = require("glob");
 var con = console;
 var pro = process;
 
@@ -98,7 +99,8 @@ exports.main = function () {
 exports.runMain = function (parsed) {
     'use strict';
 
-    var maybeExit;
+    var maybeExit,
+        remain = [];
 
     if (parsed.version) {
         exports.reportVersion(con.log, parsed);
@@ -127,10 +129,17 @@ exports.runMain = function (parsed) {
         });
     }
 
+    parsed.argv.remain.forEach(function (file) {
+        var matches = glob.sync(file).filter(function (match) {
+            return match.indexOf('node_modules') !== 0;
+        });
+        remain = remain.concat(matches);
+    });
+
     // If there are no more files to be processed, exit with the value 1
     // if any of the files contains any lint.
     maybeExit = (function () {
-        var filesLeft = parsed.argv.remain.length,
+        var filesLeft = remain.length,
             ok = true;
 
         function exitWithCode() {
@@ -153,5 +162,5 @@ exports.runMain = function (parsed) {
         };
     }());
 
-    parsed.argv.remain.forEach(lintFile);
+    remain.forEach(lintFile);
 };

--- a/package.json
+++ b/package.json
@@ -18,14 +18,16 @@
     "Dylan Lloyd",
     "Andreas Hindborg",
     "Andrew Pennebaker",
-    "Bnaya"
+    "Bnaya",
+    "Maximilian Antoni <mail@maxantoni.de>"
   ],
   "bin": {
     "jslint": "./bin/jslint.js"
   },
   "main": "./lib/nodelint.js",
   "dependencies": {
-    "nopt": "~1.0.0"
+    "nopt": "~1.0.0",
+    "glob": "~3.2.8"
   },
   "devDependencies": {
     "ronn": "0.4.0",

--- a/test/main.js
+++ b/test/main.js
@@ -98,6 +98,20 @@ suite('jslint main', function () {
         assert.ok(main);
     });
 
+    test('main - glob files', function (done) {
+        var parsed = mockParsed();
+
+        parsed.argv.remain.push('lib/mai*.js');
+
+        pro.on('exit', done);
+
+        parsed.terse = true;
+
+        main.runMain(parsed);
+
+        assert.ok(main);
+    });
+
     test('main - one file, not tty, json output', function (done) {
         var parsed = mockParsed();
 


### PR DESCRIPTION
Allow to specify glob file patterns on the command line and in package.json scripts.

With this patch, I can put a "lint" script into my package.json that does `"jslint ./**/*.js"` to lint all files in my project and it works the same way on Linux, Mac and Windows. It also ignores paths that start with `node_modules`.

Note that I've updated the instructions for "JSLint your entire project" in the README.md and added a test case.
Please let me know if there is anything to improve.
