### PR TITLE
Ignore globbed path if it contains node_modules

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -131,7 +131,7 @@ exports.runMain = function (parsed) {
 
     parsed.argv.remain.forEach(function (file) {
         var matches = glob.sync(file).filter(function (match) {
-            return match.indexOf('node_modules') !== 0;
+            return match.indexOf('node_modules') === -1;
         });
         remain = remain.concat(matches);
     });

--- a/test/main.js
+++ b/test/main.js
@@ -112,6 +112,21 @@ suite('jslint main', function () {
         assert.ok(main);
     });
 
+    test('main - glob ignore node_modules', function (done) {
+        var parsed = mockParsed();
+
+        parsed.argv.remain.push('./lib/main.js');
+        parsed.argv.remain.push('./node_modules/glob/*');
+
+        pro.on('exit', done);
+
+        parsed.terse = true;
+
+        main.runMain(parsed);
+
+        assert.ok(main);
+    });
+
     test('main - one file, not tty, json output', function (done) {
         var parsed = mockParsed();
 


### PR DESCRIPTION
The initial implementation just checked whether the path starts with `node_modules`. This changes it to ignore paths that contain `node_modules` so that `jslint './**/*.js'` works as well.
