### PR TITLE
Ignore unused parameter if they start with '_'.

### DIFF
--- a/lib/jslint.js
+++ b/lib/jslint.js
@@ -3158,7 +3158,8 @@ klass:              do {
         Object.keys(scope).forEach(function (name) {
             var master = scope[name];
             if (!master.used && master.kind !== 'exception' &&
-                    (master.kind !== 'parameter' || !option.unparam)) {
+                (master.kind !== 'parameter' || !option.unparam) &&
+		name.charAt(0) != '_' ) {
                 master.warn('unused_a');
             } else if (!master.init) {
                 master.warn('uninitialized_a');


### PR DESCRIPTION
This allow the developper to explicit which parameter can be ignored.
