### PR TITLE
Update jslint.conf.example

### DIFF
--- a/jslint.conf.example
+++ b/jslint.conf.example
@@ -3,5 +3,6 @@
     "indent":2,
     "vars":true,
     "passfail":false,
-    "plusplus":false
+    "plusplus":false,
+    "predef": "dnsDomainIs,dnsResolve,isInNet,isPlainHostName"
 }


### PR DESCRIPTION
Because there is no example for `predef`