### PR TITLE
Added quotes in the configuration file example.

### DIFF
--- a/doc/jslint.md
+++ b/doc/jslint.md
@@ -142,10 +142,10 @@ use `true` to enable and `false` to disable boolean options.  An example of a
 valid option file is:
 
  {
-   vars: true,
-   white: true,
-   maxlen: 100,
-   predef: "foo,bar,baz"
+   "vars": true,
+   "white": true,
+   "maxlen": 100,
+   "predef": "foo,bar,baz"
  }
 
 Comments are not allowed in option files.


### PR DESCRIPTION
Copy-and-pasting the configuration from the readme I was getting: 
```
Error reading config file ".jslintrc": SyntaxError: Unexpected token v
```
