### PR TITLE
Top level unused variables don't raise an error

### DIFF
--- a/test/linter.js
+++ b/test/linter.js
@@ -105,5 +105,20 @@ suite('lint', function () {
 
     });
 
+    test('top level unused var causes error', function () {
+        var script = "'use strict';\nvar unused = null;\n",
+            options = {edition: 'latest', node: true},
+            JSLINT = nodelint.load(options.edition),
+            result;
+
+        // don't let user's config interfere with our test
+        process.env.HOME = '';
+
+        result = linter.doLint(JSLINT, script, options);
+
+        assert.strictEqual(1, result.errors.length);
+        assert.deepEqual("Unused '{a}'.", result.errors[0].raw);
+    });
+
 
 });


### PR DESCRIPTION
When using JSLint with node modules, top level variables that are not used do not raise an error as expected.
This PR adds a failing unit test demonstrating the issue. I'm not sure whether this is a node-jslint or a jslint issue.

Please advice on how to get this fixed.