### PR TITLE
Fixes #133 (showing latest JSLint version in CLI)

### DIFF
--- a/lib/nodelint.js
+++ b/lib/nodelint.js
@@ -65,11 +65,16 @@ exports.load = function (edition) {
 
     vm.runInContext(jslintSource, ctx);
 
-    return ctx.JSLINT || function JSLINT(script, options) {
-        var data = ctx.jslint(script, options, options.predef);
-        JSLINT.data = function () {
-            return data;
+    if (!ctx.JSLINT) {
+        ctx.JSLINT = function JSLINT(script, options) {
+            var data = ctx.jslint(script, options, options.predef);
+            ctx.JSLINT.data = function () {
+                return data;
+            };
         };
-    };
+        ctx.JSLINT.edition = ctx.jslint('').edition;
+    }
+
+    return ctx.JSLINT;
 
 };


### PR DESCRIPTION
As latest JSLint version don't show anymore `edition` in the global it exports, and there's a need to show it, here it is. Fixes #133.