### PR TITLE
Bug fix in edition 2012-02-03, don't set s.string in 'ultimate'

### DIFF
--- a/lib/jslint-2012-02-03.js
+++ b/lib/jslint-2012-02-03.js
@@ -2571,7 +2571,7 @@ klass:              do {
         x.thru = 1;
         x.line = 0;
         x.edge = 'edge';
-        s.string = s;
+        x.string = s;
         return postscript(x);
     }
 


### PR DESCRIPTION
In edition 2012-02-03 it is assigning a field onto a string 's' instead of object 'x' causing an error. Other editions don't have this bug, so this changelist makes this edition match the other editions.

I'm running with node version v0.12.7 on OSX

Here's what the bug looks like:

    ~/node-jslint $ node bin/jslint.js --edition=2012-02-03 *
    evalmachine.<anonymous>:2574
            s.string = s;
                     ^
    TypeError: Cannot assign to read only property 'string' of (begin)
        at ultimate (evalmachine.<anonymous>:2574:18)
        at evalmachine.<anonymous>:3180:5
        at evalmachine.<anonymous>:6370:2
        at Object.exports.runInContext (vm.js:64:17)
        at Object.exports.load (/Users/afischer/node-jslint/lib/nodelint.js:66:8)
        at new LintStream_constructor (/Users/afischer/node-jslint/lib/lintstream.js:27:32)
        at Object.exports.runMain (/Users/afischer/node-jslint/lib/main.js:173:18)
        at Object.<anonymous> (/Users/afischer/node-jslint/bin/jslint.js:5:6)
        at Module._compile (module.js:460:26)
        at Object.Module._extensions..js (module.js:478:10)

Side note, this edition was working for me until a few weeks ago. I'm wondering if a new Node.js version caused this case to suddenly become an error.