### PR TITLE
Fix #182 Warning: Accessing non-existent property 'runMain'

### DIFF
--- a/lib/nodelint.js
+++ b/lib/nodelint.js
@@ -10,7 +10,11 @@ exports.LintStream = LintStream;
 
 exports.linter = linter;
 
-exports.runMain = main.runMain;
+exports.runMain = function proxy() {
+  // Proxying this fixes issue #182, "Warning: Accessing non-existent
+  // property 'runMain' of module exports inside circular dependency"
+  return main.runMain.call(null, arguments);
+};
 
 exports.setConsole = function (c) {
     'use strict';


### PR DESCRIPTION
Fixes #182.

For me, it also works nicely if I just remove this definition, but someone somewhere might need it.